### PR TITLE
OC-16142 Fixed today() function overwritten as: date('today()')

### DIFF
--- a/jsapp/xlform/src/model.rowDetail.validationLogic.coffee
+++ b/jsapp/xlform/src/model.rowDetail.validationLogic.coffee
@@ -8,7 +8,7 @@ module.exports = do ->
       operator = null
       switch type
         when 'text' then operator = new rowDetailValidationLogic.ValidationLogicTextOperator symbol
-        when 'date' then operator = new rowDetailValidationLogic.ValidationLogicDateOperator symbol
+        when 'date' then operator = new rowDetailValidationLogic.ValidationLogicTextOperator symbol
         when 'basic' then operator = new rowDetailValidationLogic.ValidationLogicBasicOperator symbol
         when 'existence' then operator = new rowDetailValidationLogic.ValidationLogicExistenceOperator symbol
         when 'select_multiple' then operator = new rowDetailValidationLogic.ValidationLogicSelectMultipleOperator symbol


### PR DESCRIPTION


# HELLO, FRIENDS! Please use `two-databases` as the base branch for all PRs. Thank you!

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure your code lints and you followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] If this is a big feature, make sure to prefix the title with `Feature:` and add a thorough description for non-dev folk

## Description

<!-- Description of the changes -->

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->

