### PR TITLE
OC-21297 Fixed econsent checking bug causing non-econsent form cannot…

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -399,7 +399,13 @@ export default assign({
       this.app.survey.settings.set('form_id', this.state.settings__form_id);
     }
 
-    const consentRows = this.app.survey.rows.filter(function(row) { return row.getValue('bind::oc:external') === 'signature' });
+    const consentRows = this.app.survey.rows.filter(function(row) { 
+      try {
+        return (row.getValue('bind::oc:external') === 'signature');
+      } catch (err) {
+        return false;
+      } 
+    });
     if (consentRows.length > 0) {
       if (consentRows.length > 1) {
         var errorMsg = `${t('Consent forms can have only one signature item.')}`;


### PR DESCRIPTION
… be saved

# HELLO, FRIENDS! Please use `two-databases` as the base branch for all PRs. Thank you!

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure your code lints and you followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] If this is a big feature, make sure to prefix the title with `Feature:` and add a thorough description for non-dev folk

## Description

<!-- Description of the changes -->

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->

