### PR TITLE
OC-27669: Logic Builder P1.1 — open the side panel

### DIFF
--- a/jsapp/js/formbuild/logicBuilderBridge.ts
+++ b/jsapp/js/formbuild/logicBuilderBridge.ts
@@ -1,0 +1,95 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {
+  LogicBuilderPanel,
+  defaultTabFor,
+  type ExpressionTab,
+  type ExpressionData,
+  type GroupKind,
+} from '@openclinica/logic-builder';
+
+const PANEL_HOST_ID = 'oc-logic-builder-host';
+
+let activeHost: HTMLElement | null = null;
+
+interface BackboneRowLike {
+  getValue: (key: string) => unknown;
+  get: (key: string) => unknown;
+}
+
+interface BackboneTypeDetail {
+  get: (key: 'typeId') => string;
+}
+
+/**
+ * Read the XLSForm columns the Logic Builder cares about off a Backbone row.
+ * Required is normalized: boolean true → 'true()' (legacy), boolean false → ''
+ * (per design-spec Backbone Bridge §Reading from Backbone).
+ */
+export function readRow(row: BackboneRowLike): ExpressionData {
+  // xlform's BaseModel.getValue throws "Could not get value" when the attribute
+  // is missing (e.g. repeat_count on a non-repeat row, calculation on a row
+  // that's never had one set). Treat missing as empty string.
+  const get = (key: string): string => {
+    let v: unknown;
+    try {
+      v = row.getValue(key);
+    } catch {
+      return '';
+    }
+    if (v === true) return 'true()';
+    if (v === false || v == null) return '';
+    return String(v);
+  };
+  const typeDetail = row.get('type') as BackboneTypeDetail | undefined;
+  return {
+    fieldName: get('name'),
+    fieldType: typeDetail ? typeDetail.get('typeId') : '',
+    calculation: get('calculation'),
+    default: get('default'),
+    relevant: get('relevant'),
+    constraint: get('constraint'),
+    constraintMessage: get('constraint_message'),
+    required: get('required'),
+    repeatCount: get('repeat_count'),
+  };
+}
+
+export interface OpenOptions {
+  row: BackboneRowLike;
+  itemType: string;
+  groupKind: GroupKind;
+  initialTab?: ExpressionTab;
+}
+
+export function openLogicBuilder(opts: OpenOptions): void {
+  closeLogicBuilder();
+
+  const data = readRow(opts.row);
+  const initialTab = opts.initialTab
+    ?? defaultTabFor(opts.itemType, opts.groupKind);
+
+  const host = document.createElement('div');
+  host.id = PANEL_HOST_ID;
+  document.body.appendChild(host);
+  activeHost = host;
+
+  ReactDOM.render(
+    React.createElement(LogicBuilderPanel, {
+      fieldName: data.fieldName || '—',
+      fieldType: data.fieldType,
+      itemType: opts.itemType,
+      groupKind: opts.groupKind,
+      initialTab,
+      onClose: closeLogicBuilder,
+    }),
+    host,
+  );
+}
+
+export function closeLogicBuilder(): void {
+  if (!activeHost) return;
+  ReactDOM.unmountComponentAtNode(activeHost);
+  activeHost.remove();
+  activeHost = null;
+}

--- a/jsapp/js/formbuild/logicBuilderBridge.ts
+++ b/jsapp/js/formbuild/logicBuilderBridge.ts
@@ -1,4 +1,8 @@
 import React from 'react';
+// TODO(react18): switch to `createRoot` / `root.unmount` from `react-dom/client`
+// when KPI's React 18 upgrade lands. `react-dom/client` does not exist on the
+// current React 16 pin, so the legacy `render` / `unmountComponentAtNode` API
+// is the only option here today.
 import ReactDOM from 'react-dom';
 import {
   LogicBuilderPanel,
@@ -62,6 +66,27 @@ export interface OpenOptions {
   initialTab?: ExpressionTab;
 }
 
+// The panel mounts into a div appended to document.body. Without a boundary,
+// any render error inside @openclinica/logic-builder would propagate to the
+// nearest ancestor boundary — and there isn't one above body — so it would
+// unmount the entire React tree on the page. Catch here and close the panel.
+type BoundaryProps = React.PropsWithChildren<{onError: () => void}>;
+class LogicBuilderErrorBoundary extends React.Component<BoundaryProps, {hasError: boolean}> {
+  state = {hasError: false};
+  static getDerivedStateFromError(): {hasError: boolean} {
+    return {hasError: true};
+  }
+  componentDidCatch(error: Error): void {
+    console.error('[LogicBuilder] render error, closing panel:', error);
+    // Defer to after the current commit so the unmount doesn't race React's
+    // own error-recovery teardown.
+    setTimeout(this.props.onError, 0);
+  }
+  render(): React.ReactNode {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
 export function openLogicBuilder(opts: OpenOptions): void {
   closeLogicBuilder();
 
@@ -75,14 +100,18 @@ export function openLogicBuilder(opts: OpenOptions): void {
   activeHost = host;
 
   ReactDOM.render(
-    React.createElement(LogicBuilderPanel, {
-      fieldName: data.fieldName || '—',
-      fieldType: data.fieldType,
-      itemType: opts.itemType,
-      groupKind: opts.groupKind,
-      initialTab,
-      onClose: closeLogicBuilder,
-    }),
+    React.createElement(
+      LogicBuilderErrorBoundary,
+      {onError: closeLogicBuilder},
+      React.createElement(LogicBuilderPanel, {
+        fieldName: data.fieldName || '—',
+        fieldType: data.fieldType,
+        itemType: opts.itemType,
+        groupKind: opts.groupKind,
+        initialTab,
+        onClose: closeLogicBuilder,
+      }),
+    ),
     host,
   );
 }

--- a/jsapp/js/formbuild/logicBuilderRow.es6
+++ b/jsapp/js/formbuild/logicBuilderRow.es6
@@ -1,0 +1,26 @@
+/**
+ * Shared helpers that derive Logic Builder context (itemType, groupKind)
+ * from a Backbone row. Used by both the click handler in view.surveyApp.coffee
+ * and the per-attribute launcher gating in view.rowDetail.coffee.
+ */
+
+/**
+ * Returns the row's xlform typeId, or '' if the row has no type detail yet.
+ */
+export function getItemType(row) {
+  const typeDetail = row && row.get('type');
+  if (!typeDetail) return '';
+  return typeDetail.get('typeId');
+}
+
+/**
+ * Returns 'repeat' for a begin_repeat group, 'nonRepeat' for a begin_group
+ * group, or null for any non-group row. The third state is what
+ * applicableTabsFor / defaultTabFor use as their group discriminator.
+ */
+export function getGroupKind(row) {
+  if (!row) return null;
+  if (row.constructor.kls !== 'Group') return null;
+  const repeatDetail = row.get('_isRepeat');
+  return repeatDetail && repeatDetail.get('value') ? 'repeat' : 'nonRepeat';
+}

--- a/jsapp/scss/main.scss
+++ b/jsapp/scss/main.scss
@@ -8,6 +8,7 @@
 @import "~react-table/react-table.css";
 @import "~alertifyjs/build/css/alertify.css";
 @import "~jquery-ui/themes/base/all.css";
+@import "~@openclinica/logic-builder/dist/style.css";
 
 @import "./libs/alertify.overrides";
 @import "./libs/react-select.overrides";

--- a/jsapp/scss/stylesheets/partials/_helpers.scss
+++ b/jsapp/scss/stylesheets/partials/_helpers.scss
@@ -33,7 +33,8 @@
   visibility: hidden;
 }
 
-.visuallyhidden {
+.visuallyhidden,
+.visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;

--- a/jsapp/scss/stylesheets/partials/_helpers.scss
+++ b/jsapp/scss/stylesheets/partials/_helpers.scss
@@ -46,7 +46,9 @@
 }
 
 .visuallyhidden.focusable:active,
-.visuallyhidden.focusable:focus {
+.visuallyhidden.focusable:focus,
+.visually-hidden.focusable:active,
+.visually-hidden.focusable:focus {
   clip: auto;
   height: auto;
   margin: 0;

--- a/jsapp/scss/stylesheets/partials/form_builder/_card.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card.scss
@@ -312,6 +312,20 @@ $cardIndicatorIconWidth: 21px;
        top: 10px;
     }
 
+    // Logic Builder icon: ƒx text glyph in blue, matching mockup
+    // (reqs-design/sbs/formdesigner/logic-builder/mockups/phase1.html:541)
+    &.card__buttons__button--logic {
+        color: #2c6cf0;
+        font-weight: 700;
+        font-size: 13px;
+        font-family: serif; // ƒ glyph reads better in serif
+        // Sits flush under the Settings (pencil) icon — no `top:` nudge.
+        // The progressive `top:` offsets on later siblings (--delete, --copy,
+        // --add) are unchanged so existing visual rhythm is preserved.
+
+        & > i { display: none; } // remove any leftover icon
+    }
+
     &.card__buttons__button--activated {
         color: colors.$kobo-gray-40;
         background-color: colors.$kobo-gray-92;
@@ -326,6 +340,22 @@ $cardIndicatorIconWidth: 21px;
     .k-icon {
       font-size: 18px;
     }
+}
+
+// Group headers are shorter than question rows but their icon strip now has
+// 5 icons (settings, fx, delete, clone, add-to-library). The cumulative
+// `top:` offsets above push the last icons past the group header height,
+// overlapping the first icons of nested rows. Inside group headers, compact
+// the icons so 5 fit without overflow.
+.group__header .card__buttons .card__buttons__button {
+  height: 16px;
+  line-height: 16px;
+
+  &.card__buttons__button--logic { top: 0; }
+  &.card__buttons__button--delete { top: 2px; }
+  &.card__buttons__button--copy,
+  &.card__buttons__button--clone { top: 4px; }
+  &.card__buttons__button--add { top: 6px; }
 }
 
 // overrides

--- a/jsapp/scss/stylesheets/partials/form_builder/_card.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card.scss
@@ -2,6 +2,11 @@
 @use 'scss/z-indexes';
 @use '~kobo-common/src/styles/colors';
 
+// Logic Builder accent. The hue is mockup-specified
+// (reqs-design/sbs/formdesigner/logic-builder/mockups/phase1.html:541) and is
+// intentionally distinct from `colors.$kobo-blue` (#2095f3 — more cyan-shifted).
+$_lb-accent: #2c6cf0;
+
 // ==========================================================================
 // Card (incl. Header and Expanded)
 // ==========================================================================
@@ -315,7 +320,7 @@ $cardIndicatorIconWidth: 21px;
     // Logic Builder icon: ƒx text glyph in blue, matching mockup
     // (reqs-design/sbs/formdesigner/logic-builder/mockups/phase1.html:541)
     &.card__buttons__button--logic {
-        color: #2c6cf0;
+        color: $_lb-accent;
         font-weight: 700;
         font-size: 13px;
         font-family: serif; // ƒ glyph reads better in serif

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
@@ -542,6 +542,32 @@ $_lb-accent: #2c6cf0;
   min-width: 0;
 }
 
+// Freestanding-wrapper variant of `.settings__input--with-launcher`: applied
+// to a child div the _isRepeat mixin builds, not to the `.settings__input`
+// container itself, so the wrapper supplies its own top spacing.
+.settings__input--with-launcher--standalone {
+  margin-top: 10px;
+}
+
+// Repeat-count label + standalone input (used by the _isRepeat mixin in
+// view.rowDetail.coffee). In the launcher case the input is reparented into
+// `.settings__input--with-launcher--standalone` and the more-specific rule
+// below flattens its top margin and lets the flex parent control width.
+.settings__repeat-count-label {
+  display: block;
+  margin-top: 10px;
+}
+
+.settings__repeat-count-input {
+  width: 85%;
+  margin-top: 10px;
+}
+
+.settings__input--with-launcher > .settings__repeat-count-input {
+  margin-top: 0;
+  width: auto;
+}
+
 // "Open in Logic Builder" launcher button (P1.1 AC2).
 // Visible glyph is the literal `ƒx` text (matches mockups/phase1.html .logic-launch).
 .card__settings__logic-builder-launcher {

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
@@ -1,6 +1,11 @@
 @use 'scss/breakpoints';
 @use '~kobo-common/src/styles/colors';
 
+// Logic Builder accent — same hue used for the item-tile ƒx button in
+// `_card.scss`. Mockup-specified (phase1.html:541); kept distinct from
+// `colors.$kobo-blue` which is a cyan-shifted shade.
+$_lb-accent: #2c6cf0;
+
 // ==========================================================================
 // Card settings tabs
 // ==========================================================================
@@ -544,10 +549,10 @@
   width: 28px;
   align-self: stretch;
   min-height: 28px;
-  border: 1px solid #c4c8cf;
+  border: 1px solid colors.$kobo-gray-85;
   border-radius: 3px;
-  background: #fff;
-  color: #2c6cf0;
+  background: colors.$kobo-white;
+  color: $_lb-accent;
   font-family: serif;
   font-size: 14px;
   font-weight: 700;
@@ -559,12 +564,12 @@
   justify-content: center;
 
   &:hover {
-    background: #eef4fc;
-    border-color: #2c6cf0;
+    background: colors.$kobo-light-blue;
+    border-color: $_lb-accent;
   }
 
   &:focus-visible {
-    outline: 2px solid #2c6cf0;
+    outline: 2px solid $_lb-accent;
     outline-offset: 1px;
   }
 }

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
@@ -512,3 +512,49 @@
         border-left: 0px;
     }
 }
+
+// Place the input + launcher on the same row, side by side.
+// Only applied when a launcher was injected — keeps existing field layouts unchanged.
+// Specificity bumped via parent class so it wins over `.card__settings__fields__field .settings__input { display: inline-block; }`.
+.card__settings__fields__field .settings__input.settings__input--with-launcher {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+
+  > textarea, > input[type="text"] {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+}
+
+// "Open in Logic Builder" launcher button (P1.1 AC2).
+// Visible glyph is the literal `ƒx` text (matches mockups/phase1.html .logic-launch).
+.card__settings__logic-builder-launcher {
+  flex: 0 0 28px;
+  width: 28px;
+  align-self: stretch;
+  min-height: 28px;
+  border: 1px solid #c4c8cf;
+  border-radius: 3px;
+  background: #fff;
+  color: #2c6cf0;
+  font-family: serif;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: #eef4fc;
+    border-color: #2c6cf0;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #2c6cf0;
+    outline-offset: 1px;
+  }
+}

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
@@ -514,17 +514,27 @@
 }
 
 // Place the input + launcher on the same row, side by side.
-// Only applied when a launcher was injected — keeps existing field layouts unchanged.
-// Specificity bumped via parent class so it wins over `.card__settings__fields__field .settings__input { display: inline-block; }`.
+// Two cases:
+//   1. The class is on the existing .settings__input span (default / calculation
+//      mixins). Specificity bump beats the inherited `display: inline-block`.
+//   2. The class is on a freestanding wrapper div around just the input +
+//      launcher (the _isRepeat mixin uses this so the surrounding checkbox +
+//      "Automatic Repeat Count:" caption keep their own line breaks).
+.settings__input--with-launcher,
 .card__settings__fields__field .settings__input.settings__input--with-launcher {
   display: flex;
   align-items: stretch;
   gap: 6px;
+}
 
-  > textarea, > input[type="text"] {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
+// `> input[type="text"]` doesn't match inputs created via `$('<input/>')`
+// without an explicit type attribute (HTML defaults to text but the attribute
+// selector requires the attribute to be present). `:not([type])` covers that.
+.settings__input--with-launcher > textarea,
+.settings__input--with-launcher > input[type="text"],
+.settings__input--with-launcher > input:not([type]) {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 // "Open in Logic Builder" launcher button (P1.1 AC2).

--- a/jsapp/xlform/src/view.row.templates.coffee
+++ b/jsapp/xlform/src/view.row.templates.coffee
@@ -125,6 +125,7 @@ module.exports = do ->
           </div>
           <div class="card__buttons">
             <span class="card__buttons__button card__buttons__button--settings card__buttons__button--gray js-toggle-card-settings" data-button-name="settings"><i class="k-icon k-icon-edit"></i></span>
+            <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
             <span class="card__buttons__button card__buttons__button--delete card__buttons__button--red js-delete-row" data-button-name="delete"><i class="k-icon k-icon-trash"></i></span>
       """
       if surveyView.features.multipleQuestions
@@ -161,6 +162,8 @@ module.exports = do ->
             <i class="k-icon k-icon-edit"></i>
           </span>
 
+          <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
+
           <span class="card__buttons__button card__buttons__button--delete card__buttons__button--red js-delete-group">
             <i class="k-icon k-icon-trash"></i>
           </span>
@@ -190,6 +193,7 @@ module.exports = do ->
           </div>
           <div class="card__buttons">
             <span class="card__buttons__button card__buttons__button--settings card__buttons__button--gray js-toggle-card-settings" data-button-name="settings"><i class="k-icon k-icon-edit"></i></span>
+            <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
             <span class="card__buttons__button card__buttons__button--delete card__buttons__button--red js-delete-row" data-button-name="delete"><i class="k-icon k-icon-trash"></i></span>
           </div>
         </div>

--- a/jsapp/xlform/src/view.row.templates.coffee
+++ b/jsapp/xlform/src/view.row.templates.coffee
@@ -125,7 +125,7 @@ module.exports = do ->
           </div>
           <div class="card__buttons">
             <span class="card__buttons__button card__buttons__button--settings card__buttons__button--gray js-toggle-card-settings" data-button-name="settings"><i class="k-icon k-icon-edit"></i></span>
-            <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
+            <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" role="button" tabindex="0" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
             <span class="card__buttons__button card__buttons__button--delete card__buttons__button--red js-delete-row" data-button-name="delete"><i class="k-icon k-icon-trash"></i></span>
       """
       if surveyView.features.multipleQuestions
@@ -162,7 +162,7 @@ module.exports = do ->
             <i class="k-icon k-icon-edit"></i>
           </span>
 
-          <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
+          <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" role="button" tabindex="0" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
 
           <span class="card__buttons__button card__buttons__button--delete card__buttons__button--red js-delete-group">
             <i class="k-icon k-icon-trash"></i>
@@ -193,7 +193,7 @@ module.exports = do ->
           </div>
           <div class="card__buttons">
             <span class="card__buttons__button card__buttons__button--settings card__buttons__button--gray js-toggle-card-settings" data-button-name="settings"><i class="k-icon k-icon-edit"></i></span>
-            <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
+            <span class="card__buttons__button card__buttons__button--logic js-open-logic-builder" data-button-name="logic-builder" role="button" tabindex="0" title="#{t("Open Logic Builder")}" aria-label="#{t("Open Logic Builder")}">ƒx</span>
             <span class="card__buttons__button card__buttons__button--delete card__buttons__button--red js-delete-row" data-button-name="delete"><i class="k-icon k-icon-trash"></i></span>
           </div>
         </div>

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -10,6 +10,26 @@ ResizeSensor = require 'css-element-queries/src/ResizeSensor'
 $viewRowDetailSkipLogic = require './view.rowDetail.SkipLogic'
 $viewTemplates = require './view.templates'
 
+{applicableTabsFor} = require '@openclinica/logic-builder'
+{getItemType, getGroupKind} = require('js/formbuild/logicBuilderRow')
+
+# HTML for a small "Open in Logic Builder" launcher button.
+# Visible glyph is the `ƒx` text per mockups/phase1.html (logic-launch class).
+# The bridge handler reads `data-logic-tab` to pre-select the panel tab.
+logicBuilderLauncherHtml = (tab, label) ->
+  """
+  <button type="button"
+          class="card__settings__logic-builder-launcher js-open-logic-builder"
+          data-logic-tab="#{tab}"
+          aria-label="#{t('Open in Logic Builder')}: #{label}"
+          title="#{t('Open in Logic Builder')}: #{label}">ƒx</button>
+  """
+
+# Whether a given Logic Builder tab applies to a row, given its Backbone model.
+isLogicTabApplicable = (row, tab) ->
+  return false unless row
+  tab in applicableTabsFor(getItemType(row), getGroupKind(row))
+
 module.exports = do ->
   viewRowDetail = {}
 
@@ -429,6 +449,9 @@ module.exports = do ->
 
       @model.facade.render @target_element
 
+      if isLogicTabApplicable(@rowView?.model, 'relevant')
+        @$el.find('.relevant__editor').append(logicBuilderLauncherHtml('relevant', t('Relevant')))
+
     insertInDOM: (rowView) ->
       @_insertInDOM rowView.cardSettingsWrap.find('.js-card-settings-skip-logic').eq(0)
 
@@ -449,6 +472,9 @@ module.exports = do ->
       @target_element = @$('.skiplogic__main')
 
       @model.facade.render @target_element
+
+      if isLogicTabApplicable(@rowView?.model, 'constraint')
+        @$el.find('.constraint__editor').append(logicBuilderLauncherHtml('constraint', t('Constraint')))
 
     insertInDOM: (rowView) ->
       @_insertInDOM rowView.cardSettingsWrap.find('.js-card-settings-validation-criteria')
@@ -622,6 +648,10 @@ module.exports = do ->
           evt.preventDefault()
           $textarea.blur()
 
+      if @model.key is 'default' and isLogicTabApplicable(@rowView?.model, 'default')
+        @$('.settings__input').addClass('settings__input--with-launcher')
+                              .append(logicBuilderLauncherHtml('default', t('Default')))
+
   viewRowDetail.DetailViewMixins._isRepeat =
     onOcCustomEvent: (ocCustomEventArgs) ->
       questionId = @model._parent.cid
@@ -664,6 +694,10 @@ module.exports = do ->
           @$repeat_count.blur()
 
       @listenForCheckboxChange()
+
+      if isLogicTabApplicable(@rowView?.model, 'repeatCount')
+        @$('.settings__input').addClass('settings__input--with-launcher')
+                              .append(logicBuilderLauncherHtml('repeatCount', t('Repeat Count')))
 
   viewRowDetail.DetailViewMixins.repeat_count =
     onOcCustomEvent: (ocCustomEventArgs) ->
@@ -1377,6 +1411,10 @@ module.exports = do ->
         if evt.key is 'Enter' or evt.keyCode is 13
           evt.preventDefault()
           $textarea.blur()
+
+      if isLogicTabApplicable(@rowView?.model, 'calculation')
+        @$('.settings__input').addClass('settings__input--with-launcher')
+                              .append(logicBuilderLauncherHtml('calculation', t('Calculation')))
 
   viewRowDetail.DetailViewMixins.select_one_from_file_filename =
     html: ->

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -661,25 +661,26 @@ module.exports = do ->
       if (sender.key is 'repeat_count') and (questionId is senderQuestionId)
         @$repeat_count.val(senderValue)
     html: ->
-      @$label_repeat_count = $('<span/>', { style: 'display: block; margin-top: 10px;' }).text(t('Automatic Repeat Count') + ":")
-      @$repeat_count = $('<input/>', { style: 'margin-top: 10px; width:85%;' }).attr('placeholder', t('(leave blank to allow users to add and remove repeats)'))
+      @$label_repeat_count = $('<span class="settings__repeat-count-label"/>').text(t('Automatic Repeat Count') + ":")
+      @$repeat_count = $('<input class="settings__repeat-count-input"/>').attr('placeholder', t('(leave blank to allow users to add and remove repeats)'))
       @$el.addClass("card__settings__fields--active")
       viewRowDetail.Templates.checkbox @cid, @model.key, t("Repeat"), t("Repeat this group if necessary")
     afterRender: ->
-      @$('.settings__input').append(@$label_repeat_count)
+      $settingsInput = @$('.settings__input')
+      $settingsInput.append(@$label_repeat_count)
 
       # The repeat-count text input sits below a checkbox + caption span, so we
       # cannot make the surrounding `.settings__input` a flex row — that would
       # collapse the line breaks. Wrap the input + launcher in their own flex
-      # container instead.
+      # container instead. The `--standalone` modifier supplies the top margin
+      # the input itself carries in the no-launcher case.
       if isLogicTabApplicable(@rowView?.model, 'repeatCount')
-        $launcherRow = $('<div class="settings__input--with-launcher" style="margin-top: 10px;"></div>')
-        @$repeat_count.css('margin-top', '0')
+        $launcherRow = $('<div class="settings__input--with-launcher settings__input--with-launcher--standalone"></div>')
         $launcherRow.append(@$repeat_count)
         $launcherRow.append(logicBuilderLauncherHtml('repeatCount', t('Repeat Count')))
-        @$('.settings__input').append($launcherRow)
+        $settingsInput.append($launcherRow)
       else
-        @$('.settings__input').append(@$repeat_count)
+        $settingsInput.append(@$repeat_count)
 
       @$repeat_count.attr('disabled', true)
 

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -667,7 +667,20 @@ module.exports = do ->
       viewRowDetail.Templates.checkbox @cid, @model.key, t("Repeat"), t("Repeat this group if necessary")
     afterRender: ->
       @$('.settings__input').append(@$label_repeat_count)
-      @$('.settings__input').append(@$repeat_count)
+
+      # The repeat-count text input sits below a checkbox + caption span, so we
+      # cannot make the surrounding `.settings__input` a flex row — that would
+      # collapse the line breaks. Wrap the input + launcher in their own flex
+      # container instead.
+      if isLogicTabApplicable(@rowView?.model, 'repeatCount')
+        $launcherRow = $('<div class="settings__input--with-launcher" style="margin-top: 10px;"></div>')
+        @$repeat_count.css('margin-top', '0')
+        $launcherRow.append(@$repeat_count)
+        $launcherRow.append(logicBuilderLauncherHtml('repeatCount', t('Repeat Count')))
+        @$('.settings__input').append($launcherRow)
+      else
+        @$('.settings__input').append(@$repeat_count)
+
       @$repeat_count.attr('disabled', true)
 
       if @model.getValue()?
@@ -694,10 +707,6 @@ module.exports = do ->
           @$repeat_count.blur()
 
       @listenForCheckboxChange()
-
-      if isLogicTabApplicable(@rowView?.model, 'repeatCount')
-        @$('.settings__input').addClass('settings__input--with-launcher')
-                              .append(logicBuilderLauncherHtml('repeatCount', t('Repeat Count')))
 
   viewRowDetail.DetailViewMixins.repeat_count =
     onOcCustomEvent: (ocCustomEventArgs) ->

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -64,6 +64,7 @@ module.exports = do ->
       "click .js-select-row--force": "forceSelectRow"
       "click .js-toggle-card-settings": "toggleCardSettings"
       "click .js-open-logic-builder": "openLogicBuilder"
+      "keydown span.js-open-logic-builder": "openLogicBuilderKey"
       "click .js-toggle-group-expansion": "toggleGroupExpansion"
       "click .js-toggle-row-multioptions": "toggleRowMultioptions"
       "click .js-close-warning": "closeWarningBox"
@@ -292,6 +293,14 @@ module.exports = do ->
         groupKind: getGroupKind(row),
         initialTab: attrTab,
       })
+
+    # Span items don't get native Enter/Space-to-click behavior; handle it
+    # so screen-reader / keyboard users can activate the item-tile button.
+    # The per-attribute launchers are real <button> elements and don't need
+    # this handler — the selector scopes to span only.
+    openLogicBuilderKey: (evt) ->
+      if evt.key is 'Enter' or evt.key is ' ' or evt.keyCode is 13 or evt.keyCode is 32
+        @openLogicBuilder(evt)
 
     toggleGroupExpansion: (evt)->
       view = @_getViewForTarget(evt)

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -12,6 +12,8 @@ isAssetLockable = require('js/components/locking/lockingUtils').isAssetLockable
 hasAssetRestriction = require('js/components/locking/lockingUtils').hasAssetRestriction
 LOCKING_RESTRICTIONS = require('js/components/locking/lockingConstants').LOCKING_RESTRICTIONS
 LOCKING_UI_CLASSNAMES = require('js/components/locking/lockingConstants').LOCKING_UI_CLASSNAMES
+logicBuilderBridge = require('js/formbuild/logicBuilderBridge')
+{getItemType, getGroupKind} = require('js/formbuild/logicBuilderRow')
 
 module.exports = do ->
   surveyApp = {}
@@ -61,6 +63,7 @@ module.exports = do ->
       "click .js-select-row": "selectRow"
       "click .js-select-row--force": "forceSelectRow"
       "click .js-toggle-card-settings": "toggleCardSettings"
+      "click .js-open-logic-builder": "openLogicBuilder"
       "click .js-toggle-group-expansion": "toggleGroupExpansion"
       "click .js-toggle-row-multioptions": "toggleRowMultioptions"
       "click .js-close-warning": "closeWarningBox"
@@ -276,6 +279,19 @@ module.exports = do ->
 
     toggleCardSettings: (evt)->
       @_getViewForTarget(evt).toggleSettings()
+
+    openLogicBuilder: (evt) ->
+      evt.preventDefault()
+      evt.stopPropagation()
+      view = @_getViewForTarget(evt)
+      row = view.model
+      attrTab = $(evt.currentTarget).data('logicTab') or undefined
+      logicBuilderBridge.openLogicBuilder({
+        row: row,
+        itemType: getItemType(row),
+        groupKind: getGroupKind(row),
+        initialTab: attrTab,
+      })
 
     toggleGroupExpansion: (evt)->
       view = @_getViewForTarget(evt)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource/roboto": "^4.4.2",
         "@fontsource/roboto-mono": "^4.4.2",
         "@mapbox/leaflet-omnivore": "^0.3.4",
+        "@openclinica/logic-builder": "github:svadla-oc/logic-builder#ea77c653bbaff233a24489b1d66e5947c2eb8b44",
         "alertifyjs": "^1.13.1",
         "backbone": "^1.4.0",
         "backbone-validation": "^0.11.5",
@@ -60,6 +61,7 @@
         "select2": "3.5.2-browserify",
         "spark-md5": "^3.0.1",
         "underscore": ">=1.12.1",
+        "userpilot": "1.4.2",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
@@ -152,6 +154,9 @@
         "npm": "8.5.5"
       }
     },
+    "../../oc-logic-builder": {
+      "extraneous": true
+    },
     "../kobo-common": {
       "version": "1.26.0",
       "extraneous": true,
@@ -174,8 +179,32 @@
         "staged-git-files": "^1.3.0"
       }
     },
+    "../oc-logic-builder": {
+      "name": "@openclinica/logic-builder",
+      "version": "0.1.0",
+      "extraneous": true,
+      "devDependencies": {
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^12.1.5",
+        "@types/react": "^16.14.0",
+        "@types/react-dom": "^16.9.0",
+        "jsdom": "^20.0.0",
+        "react": "16.13.1",
+        "react-dom": "16.13.1",
+        "sass": "^1.57.0",
+        "typescript": "~5.3.3",
+        "vite": "^4.5.0",
+        "vite-plugin-dts": "^3.6.0",
+        "vitest": "^0.34.0"
+      },
+      "peerDependencies": {
+        "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.2",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.0"
@@ -197,6 +226,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.17.7",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -204,6 +234,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.17.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
@@ -232,6 +263,7 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.0",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -241,6 +273,7 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
       "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -276,6 +309,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.17.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.17.7",
@@ -292,6 +326,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.0",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -364,6 +399,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
       "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -383,6 +419,7 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
       "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.19.0"
@@ -395,6 +432,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -426,6 +464,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.17.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.16.7",
@@ -493,6 +532,7 @@
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.17.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.17.0"
@@ -517,6 +557,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -544,6 +585,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
       "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -564,6 +606,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.17.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.16.7",
@@ -591,6 +634,7 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
       "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1896,6 +1940,7 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
       "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.20.7",
@@ -1909,6 +1954,7 @@
       "version": "7.20.12",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
       "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.20.7",
@@ -2580,6 +2626,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
       "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2593,6 +2640,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2601,6 +2649,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2618,12 +2667,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.17",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
       "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -2763,6 +2814,36 @@
       "integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==",
       "dev": true
     },
+    "node_modules/@ndhoule/each": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ndhoule/each/-/each-2.0.1.tgz",
+      "integrity": "sha512-wHuJw6x+rF6Q9Skgra++KccjBozCr9ymtna0FhxmV/8xT/hZ2ExGYR8SV8prg8x4AH/7mzDYErNGIVHuzHeybw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ndhoule/keys": "^2.0.0"
+      }
+    },
+    "node_modules/@ndhoule/includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ndhoule/includes/-/includes-2.0.1.tgz",
+      "integrity": "sha512-Q8zN6f3yIhxgBwZ5ldLozHqJlc/fRQ5+hFFsPMFeC9SJvz0nq8vG9hoRXL1c1iaNFQd7yAZIy2igQpERoFqxqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ndhoule/each": "^2.0.1"
+      }
+    },
+    "node_modules/@ndhoule/keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ndhoule/keys/-/keys-2.0.0.tgz",
+      "integrity": "sha512-vtCqKBC1Av6dsBA8xpAO+cgk051nfaI+PnmTZep2Px0vYrDvpUmLxv7z40COlWH5yCpu3gzNhepk+02yiQiZNw==",
+      "license": "MIT"
+    },
+    "node_modules/@ndhoule/pick": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ndhoule/pick/-/pick-2.0.0.tgz",
+      "integrity": "sha512-xkYtpf1pRd8egwvl5tJcdGu+GBd6ZZH3S/zoIQ9txEI+pHF9oTIlxMC9G4CB3sRugAeLgu8qYJGl3tnxWq74Qw==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "license": "MIT",
@@ -2853,6 +2934,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@openclinica/logic-builder": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/svadla-oc/logic-builder.git#ea77c653bbaff233a24489b1d66e5947c2eb8b44",
+      "integrity": "sha512-aBjOyLMEayh+L9W7DxfaUY7JvqVqFQ8eUwE4XEIh0ujrW/FlN4TYSjMzy4XWk9SNX1vXh9nf1BfoKEilZANSDg==",
+      "peerDependencies": {
+        "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -14810,6 +14900,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.20.3",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14837,6 +14928,7 @@
     },
     "node_modules/browserslist/node_modules/picocolors": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/bser": {
@@ -15291,6 +15383,7 @@
       "version": "1.0.30001464",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001464.tgz",
       "integrity": "sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -15980,6 +16073,11 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "node_modules/component-indexof": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
+      "integrity": "sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw=="
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -17647,6 +17745,7 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.122",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/element-resize-detector": {
@@ -17983,6 +18082,7 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19793,6 +19893,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -19964,6 +20065,7 @@
     },
     "node_modules/globals": {
       "version": "11.12.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -20896,6 +20998,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/is": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.2.tgz",
+      "integrity": "sha512-a2xr4E3s1PjDS8ORcGgXpWx6V+liNs+O3JRD2mb9aeugD7rtkkZ0zgLdYgw0tWsKhsdiezGYptSiMlVazCBTuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/is-absolute-url": {
@@ -21955,6 +22066,7 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -21983,6 +22095,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -22103,36 +22216,6 @@
         "stylelint": "^14.16.1",
         "stylelint-config-standard-scss": "^6.1.0",
         "typescript": "^4.6.2"
-      }
-    },
-    "node_modules/kobo-common/node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "peer": true
-    },
-    "node_modules/kobo-common/node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/kobo-common/node_modules/postcss-scss": {
@@ -23585,6 +23668,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-package-data": {
@@ -23651,6 +23735,12 @@
     "node_modules/num2fraction": {
       "version": "1.2.2",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obj-case": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==",
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -30319,6 +30409,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/userpilot": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/userpilot/-/userpilot-1.4.2.tgz",
+      "integrity": "sha512-PyOu0TXrH0NlK0sw7l3vWuXKbz92AZaUa2QmemobQ3dvOCW8cJd+d7NX3NHdyOKBakrXy76S1TQJscUEBx5nTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ndhoule/includes": "^2.0.1",
+        "@ndhoule/pick": "^2.0.0",
+        "component-indexof": "0.0.3",
+        "is": "^3.1.0",
+        "obj-case": "^0.2.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -31906,6 +32009,7 @@
   "dependencies": {
     "@ampproject/remapping": {
       "version": "2.1.2",
+      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
@@ -31919,10 +32023,12 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.7"
+      "version": "7.17.7",
+      "dev": true
     },
     "@babel/core": {
       "version": "7.17.9",
+      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -31942,7 +32048,8 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "dev": true
         }
       }
     },
@@ -31950,6 +32057,7 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
       "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -31975,6 +32083,7 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.17.7",
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
@@ -31983,7 +32092,8 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "dev": true
         }
       }
     },
@@ -32034,7 +32144,8 @@
     "@babel/helper-environment-visitor": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.16.7",
@@ -32047,6 +32158,7 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
       "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.19.0"
@@ -32056,6 +32168,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -32077,6 +32190,7 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.17.7",
+      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
@@ -32127,6 +32241,7 @@
     },
     "@babel/helper-simple-access": {
       "version": "7.17.7",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.17.0"
       }
@@ -32144,6 +32259,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -32161,7 +32277,8 @@
     "@babel/helper-validator-option": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.16.8",
@@ -32175,6 +32292,7 @@
     },
     "@babel/helpers": {
       "version": "7.17.9",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.9",
@@ -32194,7 +32312,8 @@
     "@babel/parser": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg=="
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+      "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.16.7",
@@ -32961,6 +33080,7 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
       "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.20.7",
@@ -32971,6 +33091,7 @@
       "version": "7.20.12",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
       "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.20.7",
@@ -33495,6 +33616,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
       "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -33504,12 +33626,14 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
     },
     "@jridgewell/source-map": {
       "version": "0.3.2",
@@ -33524,12 +33648,14 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.17",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
       "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
@@ -33617,8 +33743,7 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -33643,6 +33768,32 @@
           "dev": true
         }
       }
+    },
+    "@ndhoule/each": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ndhoule/each/-/each-2.0.1.tgz",
+      "integrity": "sha512-wHuJw6x+rF6Q9Skgra++KccjBozCr9ymtna0FhxmV/8xT/hZ2ExGYR8SV8prg8x4AH/7mzDYErNGIVHuzHeybw==",
+      "requires": {
+        "@ndhoule/keys": "^2.0.0"
+      }
+    },
+    "@ndhoule/includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ndhoule/includes/-/includes-2.0.1.tgz",
+      "integrity": "sha512-Q8zN6f3yIhxgBwZ5ldLozHqJlc/fRQ5+hFFsPMFeC9SJvz0nq8vG9hoRXL1c1iaNFQd7yAZIy2igQpERoFqxqg==",
+      "requires": {
+        "@ndhoule/each": "^2.0.1"
+      }
+    },
+    "@ndhoule/keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ndhoule/keys/-/keys-2.0.0.tgz",
+      "integrity": "sha512-vtCqKBC1Av6dsBA8xpAO+cgk051nfaI+PnmTZep2Px0vYrDvpUmLxv7z40COlWH5yCpu3gzNhepk+02yiQiZNw=="
+    },
+    "@ndhoule/pick": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ndhoule/pick/-/pick-2.0.0.tgz",
+      "integrity": "sha512-xkYtpf1pRd8egwvl5tJcdGu+GBd6ZZH3S/zoIQ9txEI+pHF9oTIlxMC9G4CB3sRugAeLgu8qYJGl3tnxWq74Qw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -33698,6 +33849,11 @@
           }
         }
       }
+    },
+    "@openclinica/logic-builder": {
+      "version": "git+ssh://git@github.com/svadla-oc/logic-builder.git#ea77c653bbaff233a24489b1d66e5947c2eb8b44",
+      "integrity": "sha512-aBjOyLMEayh+L9W7DxfaUY7JvqVqFQ8eUwE4XEIh0ujrW/FlN4TYSjMzy4XWk9SNX1vXh9nf1BfoKEilZANSDg==",
+      "from": "@openclinica/logic-builder@github:svadla-oc/logic-builder#ea77c653bbaff233a24489b1d66e5947c2eb8b44"
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",
@@ -35383,8 +35539,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
           "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "webpack-sources": {
           "version": "1.4.3",
@@ -37549,8 +37704,7 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
           "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
@@ -41352,8 +41506,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -41364,8 +41517,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.6.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -41403,8 +41555,7 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -41486,8 +41637,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -41514,8 +41664,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alertifyjs": {
       "version": "1.13.1"
@@ -42536,6 +42685,7 @@
     },
     "browserslist": {
       "version": "4.20.3",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001332",
         "electron-to-chromium": "^1.4.118",
@@ -42545,7 +42695,8 @@
       },
       "dependencies": {
         "picocolors": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         }
       }
     },
@@ -42883,7 +43034,8 @@
     "caniuse-lite": {
       "version": "1.0.30001464",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001464.tgz",
-      "integrity": "sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g=="
+      "integrity": "sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g==",
+      "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -43070,8 +43222,7 @@
     },
     "circular-dependency-plugin": {
       "version": "5.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -43366,6 +43517,11 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "component-indexof": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
+      "integrity": "sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw=="
     },
     "compressible": {
       "version": "2.0.18",
@@ -44635,7 +44791,8 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.122"
+      "version": "1.4.122",
+      "dev": true
     },
     "element-resize-detector": {
       "version": "1.2.4",
@@ -44906,7 +45063,8 @@
       "dev": true
     },
     "escalade": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -45087,8 +45245,7 @@
     "eslint-config-prettier": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "requires": {}
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q=="
     },
     "eslint-plugin-react": {
       "version": "7.30.1",
@@ -46205,7 +46362,8 @@
       }
     },
     "gensync": {
-      "version": "1.0.0-beta.2"
+      "version": "1.0.0-beta.2",
+      "dev": true
     },
     "geometry-interfaces": {
       "version": "1.1.4",
@@ -46315,7 +46473,8 @@
       }
     },
     "globals": {
-      "version": "11.12.0"
+      "version": "11.12.0",
+      "dev": true
     },
     "globalthis": {
       "version": "1.0.3",
@@ -46344,8 +46503,7 @@
     "goober": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.10.tgz",
-      "integrity": "sha512-7PpuQMH10jaTWm33sQgBQvz45pHR8N4l3Cu3WMGEWmHShAcTuuP7I+5/DwKo39fwti5A80WAjvqgz6SSlgWmGA==",
-      "requires": {}
+      "integrity": "sha512-7PpuQMH10jaTWm33sQgBQvz45pHR8N4l3Cu3WMGEWmHShAcTuuP7I+5/DwKo39fwti5A80WAjvqgz6SSlgWmGA=="
     },
     "gopd": {
       "version": "1.0.1",
@@ -46851,8 +47009,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -46957,6 +47114,11 @@
     "ipaddr.js": {
       "version": "2.0.1",
       "dev": true
+    },
+    "is": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.2.tgz",
+      "integrity": "sha512-a2xr4E3s1PjDS8ORcGgXpWx6V+liNs+O3JRD2mb9aeugD7rtkkZ0zgLdYgw0tWsKhsdiezGYptSiMlVazCBTuQ=="
     },
     "is-absolute-url": {
       "version": "3.0.3",
@@ -47681,7 +47843,8 @@
       }
     },
     "jsesc": {
-      "version": "2.5.2"
+      "version": "2.5.2",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -47699,7 +47862,8 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "json5": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -47790,28 +47954,10 @@
         "typescript": "^4.6.2"
       },
       "dependencies": {
-        "picocolors": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-          "peer": true
-        },
-        "postcss": {
-          "version": "8.4.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-          "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
-          "peer": true,
-          "requires": {
-            "nanoid": "^3.3.4",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.2"
-          }
-        },
         "postcss-scss": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
-          "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
-          "requires": {}
+          "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ=="
         },
         "stylelint-config-recommended-scss": {
           "version": "8.0.0",
@@ -47884,8 +48030,7 @@
     "leaflet.markercluster": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
-      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
-      "requires": {}
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA=="
     },
     "levn": {
       "version": "0.4.1",
@@ -48528,8 +48673,7 @@
     "mobx-react-lite": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
-      "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
-      "requires": {}
+      "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ=="
     },
     "mocha": {
       "version": "7.2.0",
@@ -48876,7 +49020,8 @@
       }
     },
     "node-releases": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -48926,6 +49071,11 @@
     "num2fraction": {
       "version": "1.2.2",
       "dev": true
+    },
+    "obj-case": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg=="
     },
     "object-assign": {
       "version": "4.1.1"
@@ -49716,8 +49866,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -50188,8 +50337,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
       "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-document-title": {
       "version": "2.0.3",
@@ -50395,8 +50543,7 @@
       }
     },
     "react-tagsinput": {
-      "version": "3.19.0",
-      "requires": {}
+      "version": "3.19.0"
     },
     "react-transition-group": {
       "version": "4.4.2",
@@ -52511,8 +52658,7 @@
         "@csstools/selector-specificity": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.0.tgz",
-          "integrity": "sha512-zJ6hb3FDgBbO8d2e83vg6zq7tNvDqSq9RwdwfzJ8tdm9JHNvANq2fqwyRn6mlpUb7CwTs5ILdUrGwi9Gk4vY5w==",
-          "requires": {}
+          "integrity": "sha512-zJ6hb3FDgBbO8d2e83vg6zq7tNvDqSq9RwdwfzJ8tdm9JHNvANq2fqwyRn6mlpUb7CwTs5ILdUrGwi9Gk4vY5w=="
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -52656,8 +52802,7 @@
         "postcss-safe-parser": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-          "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-          "requires": {}
+          "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ=="
         },
         "quick-lru": {
           "version": "4.0.1",
@@ -52778,8 +52923,7 @@
     "stylelint-config-recommended": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-      "integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
-      "requires": {}
+      "integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ=="
     },
     "stylelint-config-standard": {
       "version": "29.0.0",
@@ -52874,8 +53018,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.3.tgz",
       "integrity": "sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "symbol.prototype.description": {
       "version": "1.0.5",
@@ -53720,6 +53863,18 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "userpilot": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/userpilot/-/userpilot-1.4.2.tgz",
+      "integrity": "sha512-PyOu0TXrH0NlK0sw7l3vWuXKbz92AZaUa2QmemobQ3dvOCW8cJd+d7NX3NHdyOKBakrXy76S1TQJscUEBx5nTw==",
+      "requires": {
+        "@ndhoule/includes": "^2.0.1",
+        "@ndhoule/pick": "^2.0.0",
+        "component-indexof": "0.0.3",
+        "is": "^3.1.0",
+        "obj-case": "^0.2.0"
+      }
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -54176,8 +54331,7 @@
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "enhanced-resolve": {
           "version": "5.12.0",
@@ -54451,8 +54605,7 @@
           "version": "8.13.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
           "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -54460,8 +54613,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/webpack-extract-translation-keys-plugin/-/webpack-extract-translation-keys-plugin-6.0.0.tgz",
       "integrity": "sha512-QjW1wrXkplsGZP5hysOYPL7CsjhXBUMQ7O1i73nQkMft0uWfggdeH79JKWvTN66VZYZuM4CS80dGwl2E+BpoLw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "webpack-hot-middleware": {
       "version": "2.25.3",
@@ -54738,8 +54890,7 @@
     },
     "ws": {
       "version": "7.5.7",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "x-default-browser": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^4.4.2",
+    "@openclinica/logic-builder": "github:OpenClinica/logic-builder#ea77c653bbaff233a24489b1d66e5947c2eb8b44",
     "@fontsource/roboto-mono": "^4.4.2",
     "@mapbox/leaflet-omnivore": "^0.3.4",
     "alertifyjs": "^1.13.1",

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ require('./xlform/deserializer.tests');
 require('./xlform/group.tests');
 require('./xlform/icons.tests');
 require('./xlform/inputParser.tests');
+require('./xlform/logicBuilderRow.tests');
 require('./xlform/questionTypeForms.tests');
 require('./xlform/rowDetail.tests');
 require('./xlform/rowSelector.tests');

--- a/test/xlform/logicBuilderRow.tests.coffee
+++ b/test/xlform/logicBuilderRow.tests.coffee
@@ -1,0 +1,130 @@
+chai = require('chai')
+expect = chai.expect
+$ = require('jquery')
+_ = require('underscore')
+
+# Provide translation stub (no Django runtime in tests)
+window.t ?= (str) -> str
+
+$rowTemplates = require('../../jsapp/xlform/src/view.row.templates')
+
+describe 'Logic Builder item-tile button (P1.1 AC1)', ->
+  describe 'view.row.templates.xlfRowView', ->
+    beforeEach ->
+      @surveyView = {features: {multipleQuestions: true}, canAddToLibrary: false}
+      @html = $rowTemplates.xlfRowView(@surveyView)
+      @$frag = $('<div>').html(@html)
+
+    it 'renders a Logic Builder icon button on a question row tile', ->
+      expect(@$frag.find('.card__buttons .js-open-logic-builder').length).to.equal(1)
+
+    it 'positions the Logic Builder button immediately after the Settings button', ->
+      $strip = @$frag.find('.card__header .card__buttons').eq(0)
+      $children = $strip.children()
+      settingsIdx = $children.index($strip.find('.js-toggle-card-settings'))
+      logicIdx = $children.index($strip.find('.js-open-logic-builder'))
+      expect(logicIdx).to.equal(settingsIdx + 1)
+
+  describe 'view.row.templates.groupView', ->
+    beforeEach ->
+      @surveyView = {features: {multipleQuestions: true}, canAddToLibrary: false}
+      @html = $rowTemplates.groupView(@surveyView)
+      @$frag = $('<div>').html(@html)
+
+    it 'renders the Logic Builder button on a group tile', ->
+      expect(@$frag.find('.group__header .card__buttons .js-open-logic-builder').length).to.be.at.least(1)
+
+  describe 'view.row.templates.koboMatrixView', ->
+    beforeEach ->
+      @html = $rowTemplates.koboMatrixView()
+      @$frag = $('<div>').html(@html)
+
+    it 'renders the Logic Builder button on a matrix question tile', ->
+      expect(@$frag.find('.card__buttons .js-open-logic-builder').length).to.equal(1)
+
+# Helper: build a DetailView for a given attribute key on a given row, render it,
+# and return the resulting $el. Stubs `@model.facade.render` so the relevant /
+# constraint editors don't need the full SkipLogic facade in tests.
+buildDetailEl = (row, key) ->
+  $viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+  detailModel = row.get(key)
+  if detailModel?.facade?
+    detailModel.facade = {render: ->}
+  view = new $viewRowDetail.DetailView(model: detailModel, rowView: {model: row})
+  view.render()
+  view.$el
+
+describe 'Logic Builder per-attribute launchers (P1.1 AC2)', ->
+  beforeEach ->
+    window.xlfHideWarnings = true
+    @$model = require('../../jsapp/xlform/src/_model')
+  afterEach ->
+    window.xlfHideWarnings = false
+
+  it 'shows a Calculation launcher for ordinary question items', ->
+    survey = new @$model.Survey()
+    survey.rows.add(type: 'decimal', name: 'q1', label: 'Q1')
+    row = survey.rows.at(0)
+    $el = buildDetailEl(row, 'calculation')
+    expect($el.find('.js-open-logic-builder[data-logic-tab="calculation"]').length).to.equal(1)
+
+  it 'shows a Relevant launcher for ordinary question items', ->
+    survey = new @$model.Survey()
+    survey.rows.add(type: 'decimal', name: 'q1', label: 'Q1')
+    row = survey.rows.at(0)
+    $el = buildDetailEl(row, 'relevant')
+    expect($el.find('.js-open-logic-builder[data-logic-tab="relevant"]').length).to.equal(1)
+
+  it 'shows a Constraint launcher for ordinary question items', ->
+    survey = new @$model.Survey()
+    survey.rows.add(type: 'decimal', name: 'q1', label: 'Q1')
+    row = survey.rows.at(0)
+    $el = buildDetailEl(row, 'constraint')
+    expect($el.find('.js-open-logic-builder[data-logic-tab="constraint"]').length).to.equal(1)
+
+  it 'shows a Default launcher for ordinary question items', ->
+    survey = new @$model.Survey()
+    survey.rows.add(type: 'decimal', name: 'q1', label: 'Q1')
+    row = survey.rows.at(0)
+    $el = buildDetailEl(row, 'default')
+    expect($el.find('.js-open-logic-builder[data-logic-tab="default"]').length).to.equal(1)
+
+  it 'does NOT show a Calculation launcher inside a note item (note has only Relevant)', ->
+    survey = new @$model.Survey()
+    survey.rows.add(type: 'note', name: 'n1', label: 'Note')
+    row = survey.rows.at(0)
+    $calcEl = buildDetailEl(row, 'calculation')
+    expect($calcEl.find('.js-open-logic-builder[data-logic-tab="calculation"]').length).to.equal(0)
+    $relEl = buildDetailEl(row, 'relevant')
+    expect($relEl.find('.js-open-logic-builder[data-logic-tab="relevant"]').length).to.equal(1)
+
+  it 'does NOT show a Constraint launcher inside a calculate item (calculate has only Calculation, Default)', ->
+    survey = new @$model.Survey()
+    survey.rows.add(type: 'calculate', name: 'c1', label: 'Calc', calculation: '1+1')
+    row = survey.rows.at(0)
+    $constraintEl = buildDetailEl(row, 'constraint')
+    expect($constraintEl.find('.js-open-logic-builder[data-logic-tab="constraint"]').length).to.equal(0)
+    $calcEl = buildDetailEl(row, 'calculation')
+    expect($calcEl.find('.js-open-logic-builder[data-logic-tab="calculation"]').length).to.equal(1)
+
+  it 'shows a Repeat Count launcher only on repeat groups', ->
+    survey = @$model.Survey.load(survey: [
+      ['type',         'name', 'label']
+      ['begin repeat', 'rg1',  'RG1']
+      ['text',         'q1',   'Q1']
+      ['end repeat']
+    ])
+    groupRow = _.first(survey.rows.filter (r) -> r.constructor.kls is 'Group')
+    $el = buildDetailEl(groupRow, '_isRepeat')
+    expect($el.find('.js-open-logic-builder[data-logic-tab="repeatCount"]').length).to.equal(1)
+
+  it 'does NOT show a Repeat Count launcher on a non-repeat group', ->
+    survey = @$model.Survey.load(survey: [
+      ['type',        'name', 'label']
+      ['begin group', 'g1',   'G1']
+      ['text',        'q1',   'Q1']
+      ['end group']
+    ])
+    groupRow = _.first(survey.rows.filter (r) -> r.constructor.kls is 'Group')
+    $el = buildDetailEl(groupRow, '_isRepeat')
+    expect($el.find('.js-open-logic-builder[data-logic-tab="repeatCount"]').length).to.equal(0)

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -89,6 +89,11 @@ const commonOptions = {
       scss: path.join(__dirname, '../jsapp/scss'),
       utils: path.join(__dirname, '../jsapp/js/utils'),
       test: path.join(__dirname, '../test'),
+      // Dedupe React across kpi and any linked package (e.g. @openclinica/logic-builder).
+      // Without this, a sibling package with its own node_modules/react in devDeps gets
+      // bundled twice, causing React error #321 (invalid hook call).
+      react: path.join(__dirname, '../node_modules/react'),
+      'react-dom': path.join(__dirname, '../node_modules/react-dom'),
     },
   },
   plugins: [


### PR DESCRIPTION
Wire the @openclinica/logic-builder React panel into the Backbone-based form designer. Adds the ƒx item-tile button (AC1), per-attribute launchers beside inline expression fields (AC2), context-aware tabs and default-tab selection per item type (AC3/AC4), and the three-line header with × and Esc close (AC5). NL input, Generate, Save Expression, pinning, and unsaved-changes prompts land with P1.2+. The bridge passes a single GroupKind discriminator to the panel; webpack aliases react/react-dom to dedupe across the linked package and prevent React error #321.

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
