### PR TITLE
OC-27511 Error/messages for conditional field in FD is too light in color and visiblity to be properly read.

### DIFF
--- a/jsapp/scss/stylesheets/partials/form_builder/_mandatory_setting.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_mandatory_setting.scss
@@ -11,6 +11,10 @@
       .text-box {
         margin-top: 5px;
         display: block;
+
+        input[type="text"] {
+          background-color: colors.$kobo-white;
+        }
       }
 
       input[type='radio']:not(:checked) ~ .text-box {
@@ -21,10 +25,10 @@
       }
 
       .input-error {
-        color: colors.$kobo-light-red;
-    
+        color: colors.$kobo-red;
+
         input[type="text"] {
-          border-color: colors.$kobo-light-red;
+          border-color: colors.$kobo-red;
         }
       }
     }


### PR DESCRIPTION
## Checklist

1. [Y ] If you've added code that should be tested, add tests
2. [X] If you've changed APIs, update (or create!) the documentation
3. [Y] Ensure the tests pass
4. [Y] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Error/messages for conditional field in FD is too light in color and visiblity to be properly read.

<img width="1715" height="612" alt="image" src="https://github.com/user-attachments/assets/2fcd8037-c1b3-42bf-b1bb-928b899003d8" />


## Related issues
https://jira.openclinica.com/browse/OC-27511
