### PR TITLE
OC-27687 Remove "Use External Value" field from PII (encrypted) items

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1199,6 +1199,16 @@ module.exports = do ->
       @fieldTab = "active"
       @$el.addClass("card__settings__fields--#{@fieldTab}")
 
+      # For PII (Encrypted) items, the "Use External Value" dropdown is always
+      # "contactdata" and must never be shown or edited. Render a properly
+      # structured Contact Data Type field instead.
+      if @model.get('value') is 'contactdata'
+        return viewRowDetail.Templates.field(
+          '<select class="contact-data-type"></select>',
+          @cid,
+          t("Contact Data Type")
+        )
+
       if @model_type() in ['calculate', 'text'] or (@model_type() == 'select_multiple' and @model._parent.isConsentItem())
         options = @getOptions()
         if options?
@@ -1289,6 +1299,48 @@ module.exports = do ->
         @rowView.model.attributes['instance::oc:identifier'].set 'value', ''
 
       modelValue = @model.get 'value'
+
+      # PII (Encrypted) items: The "Use External Value" dropdown is hidden and
+      # replaced with a "Contact Data Type" dropdown rendered by html().
+      # Handle this case FIRST before the general $select.length check.
+      if modelValue is 'contactdata'
+        $contactDataSelect = @$('select.contact-data-type')
+        if $contactDataSelect.length > 0
+          Backbone.trigger('ocCustomEvent', { sender: @model, value: 'contactdata' })
+
+          for opt in @contact_data_type_options
+            $('<option />', {value: opt.value, text: opt.label}).appendTo($contactDataSelect)
+
+          syncContactDataTypeToItemType = () =>
+            selectedContactDataType = $contactDataSelect.val()
+            typeDetail = @rowView.model.get('type')
+            return  unless typeDetail?
+
+            isExternalContactData = @rowView.model.getValue?('bind::oc:external') is 'contactdata'
+            return  unless isExternalContactData
+
+            if selectedContactDataType is 'fulldob'
+              if typeDetail.get('typeId') is 'text'
+                typeDetail.set('value', 'date')
+            else
+              if typeDetail.get('typeId') is 'date'
+                typeDetail.set('value', 'text')
+
+          instance_contactdata_value = @rowView.model.attributes['instance::oc:contactdata'].get 'value'
+          contact_data_values = (opt.value for opt in @contact_data_type_options)
+          if instance_contactdata_value != '' and (instance_contactdata_value in contact_data_values)
+            $contactDataSelect.val(instance_contactdata_value)
+          else
+            $contactDataSelect.val('firstname')
+            @rowView.model.attributes['instance::oc:contactdata'].set 'value', 'firstname'
+
+          syncContactDataTypeToItemType()
+
+          $contactDataSelect.change () =>
+            @rowView.model.attributes['instance::oc:contactdata'].set 'value', $contactDataSelect.val()
+            syncContactDataTypeToItemType()
+          return
+
       if $select.length > 0
         if modelValue == ''
           if @model._parent.isConsentItem()

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1204,7 +1204,7 @@ module.exports = do ->
       # structured Contact Data Type field instead.
       if @model.get('value') is 'contactdata'
         return viewRowDetail.Templates.field(
-          '<select class="contact-data-type"></select>',
+          "<select id=\"#{@cid}\" name=\"#{@model.key}\" class=\"contact-data-type\"></select>",
           @cid,
           t("Contact Data Type")
         )

--- a/jsapp/xlform/src/view.rowSelector.coffee
+++ b/jsapp/xlform/src/view.rowSelector.coffee
@@ -123,6 +123,7 @@ module.exports = do ->
         rowDetails.type = 'text'
         rowDetails['bind::oc:external'] = 'contactdata'
         rowDetails['bind::oc:itemgroup'] = ''
+        rowDetails['instance::oc:contactdata'] = 'firstname'
 
       rowDetails.label = questionLabelValue
 

--- a/test/xlform/rowSelector.tests.coffee
+++ b/test/xlform/rowSelector.tests.coffee
@@ -323,6 +323,9 @@ do ->
       @selector.onSelectNewQuestionType(buildPickerEvent('pii_encrypted'))
       expect(@survey.rows.at(1).getValue('bind::oc:external')).toBe('contactdata')
 
+    it 'pii_encrypted row sets instance::oc:contactdata to "firstname" at creation', ->
+      expect(@survey.rows.at(0).getValue('instance::oc:contactdata')).toBe('firstname')
+
     it 'pii_encrypted row with empty label still sets bind::oc:external to "contactdata"', ->
       survey3 = new $model.Survey()
       selector3 = buildRowSelector(survey: survey3)

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -397,13 +397,13 @@ do ->
       result = @mixin_ctx.html()
       expect(result.indexOf('type="text"')).not.toBe(-1)
 
-    it 'oc_briefdescription html() renders "Item Brief Description" label', ->
+    it 'oc_briefdescription html() renders "Short Display Name" label', ->
       result = @mixin_ctx.html()
-      expect(result.indexOf('Item Brief Description')).not.toBe(-1)
+      expect(result.indexOf('Short Display Name')).not.toBe(-1)
 
     it 'oc_briefdescription html() renders the correct placeholder', ->
       result = @mixin_ctx.html()
-      expect(result.indexOf('Enter Text')).not.toBe(-1)
+      expect(result.indexOf('column header')).not.toBe(-1)
 
     it 'oc_briefdescription html() renders maxlength="40"', ->
       result = @mixin_ctx.html()
@@ -435,9 +435,9 @@ do ->
       result = @mixin_ctx.html()
       expect(result.indexOf('Item Description')).not.toBe(-1)
 
-    it 'oc_description html() renders the Enter Text placeholder', ->
+    it 'oc_description html() renders the correct placeholder', ->
       result = @mixin_ctx.html()
-      expect(result.indexOf('Enter Text')).not.toBe(-1)
+      expect(result.indexOf('Enter item definition')).not.toBe(-1)
 
     it 'oc_description html() renders maxlength="3999"', ->
       result = @mixin_ctx.html()
@@ -664,64 +664,59 @@ do ->
       row = result.survey.find((r) -> r.name is 'pii_q')
       expect(row['bind::oc:external']).toBeUndefined()
 
-    it 'exports instance::oc:contactdata (contact_data_type) in survey JSON when set', ->
-      $model = require('../../jsapp/xlform/src/_model')
-      survey = new $model.Survey()
-      survey.rows.add(type: 'text', name: 'pii_q', label: 'Patient Name')
-      row = survey.rows.at(0)
-      row.get('bind::oc:external').set('value', 'contactdata')
-      row.get('instance::oc:contactdata').set('value', 'email')
-      result = survey.toJSON()
-      exportedRow = result.survey[0]
-      expect(exportedRow['instance::oc:contactdata']).toBe('email')
-
-  ###############################################################
-  # OC-26560 — Use External Value hidden for PII (Encrypted) items
-  ###############################################################
-  describe 'view.rowDetail: PII — oc_external html() hidden for contactdata value', ->
+  describe 'view.rowDetail: PII — fulldob type switching via Contact Data Type dropdown', ->
     beforeEach ->
       window.xlfHideWarnings = true
       @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
       $model = require('../../jsapp/xlform/src/_model')
-      survey = new $model.Survey()
-      survey.rows.add(type: 'text', name: 'pii_q', label: 'Patient Name')
-      @row = survey.rows.at(0)
+
+      @survey = new $model.Survey()
+      @survey.rows.add(
+        type: 'text'
+        name: 'pii_dob'
+        label: 'Date of Birth'
+        'bind::oc:external': 'contactdata'
+        'instance::oc:contactdata': 'firstname'
+      )
+      @row = @survey.rows.at(0)
       @detail = @row.get('bind::oc:external')
-      @detail.set('value', 'contactdata')
       @mixin = @viewRowDetail.DetailViewMixins.oc_external
-      @mixin_ctx = $.extend({}, @mixin, {
-        cid: 'cid_ext_pii'
-        $el: $('<div/>')
+
+      # Create DOM element with contact-data-type select rendered by html()
+      htmlResult = @mixin.html.call({
+        fieldTab: 'active'
+        $el: { addClass: -> }
         model: @detail
-        rowView: {model: @row}
-        Templates: @viewRowDetail.Templates
+        cid: 'cid_dob'
       })
+      @$el = $('<div/>').html(htmlResult)
+
+      @mixin_ctx = $.extend({}, @mixin, {
+        cid: 'cid_dob'
+        $el: @$el
+        $: (selector) => @$el.find(selector)
+        model: @detail
+        rowView: { model: @row }
+        contact_data_type_options: [
+          {value: 'firstname', label: 'firstname'}
+          {value: 'fulldob', label: 'fulldob'}
+        ]
+      })
+
     afterEach ->
       window.xlfHideWarnings = false
 
-    it 'html() renders a Contact Data Type <select> for a PII item', ->
-      result = @mixin_ctx.html()
-      expect(result.indexOf('<select')).not.toBe(-1)
-      expect(result.indexOf('contact-data-type')).not.toBe(-1)
+    it 'selecting "fulldob" changes row type from text to date', ->
+      expect(@row.getValue('type')).toBe('text')
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $contactDataSelect = @$el.find('select.contact-data-type')
+      $contactDataSelect.val('fulldob').trigger('change')
+      expect(@row.getValue('type')).toBe('date')
 
-    it 'html() renders "Contact Data Type" label for a PII item', ->
-      result = @mixin_ctx.html()
-      expect(result.indexOf('Contact Data Type')).not.toBe(-1)
-
-    it 'html() renders a settings__input container for a PII item', ->
-      result = @mixin_ctx.html()
-      expect(result.indexOf('settings__input')).not.toBe(-1)
-
-    it 'html() does NOT render "Use External Value" label for a PII item', ->
-      result = @mixin_ctx.html()
-      expect(result.indexOf('Use External Value')).toBe(-1)
-
-    it 'html() still renders <select> for a text item with empty bind::oc:external', ->
-      @detail.set('value', '')
-      result = @mixin_ctx.html()
-      expect(result.indexOf('<select')).not.toBe(-1)
-
-    it 'html() still renders "Use External Value" label for non-PII text item', ->
-      @detail.set('value', '')
-      result = @mixin_ctx.html()
-      expect(result.indexOf('Use External Value')).not.toBe(-1)
+    it 'selecting another type after fulldob changes row type back to text', ->
+      @row.get('type').set('value', 'date')
+      expect(@row.getValue('type')).toBe('date')
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $contactDataSelect = @$el.find('select.contact-data-type')
+      $contactDataSelect.val('firstname').trigger('change')
+      expect(@row.getValue('type')).toBe('text')

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -663,3 +663,65 @@ do ->
       result = survey.toJSON()
       row = result.survey.find((r) -> r.name is 'pii_q')
       expect(row['bind::oc:external']).toBeUndefined()
+
+    it 'exports instance::oc:contactdata (contact_data_type) in survey JSON when set', ->
+      $model = require('../../jsapp/xlform/src/_model')
+      survey = new $model.Survey()
+      survey.rows.add(type: 'text', name: 'pii_q', label: 'Patient Name')
+      row = survey.rows.at(0)
+      row.get('bind::oc:external').set('value', 'contactdata')
+      row.get('instance::oc:contactdata').set('value', 'email')
+      result = survey.toJSON()
+      exportedRow = result.survey[0]
+      expect(exportedRow['instance::oc:contactdata']).toBe('email')
+
+  ###############################################################
+  # OC-26560 — Use External Value hidden for PII (Encrypted) items
+  ###############################################################
+  describe 'view.rowDetail: PII — oc_external html() hidden for contactdata value', ->
+    beforeEach ->
+      window.xlfHideWarnings = true
+      @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      $model = require('../../jsapp/xlform/src/_model')
+      survey = new $model.Survey()
+      survey.rows.add(type: 'text', name: 'pii_q', label: 'Patient Name')
+      @row = survey.rows.at(0)
+      @detail = @row.get('bind::oc:external')
+      @detail.set('value', 'contactdata')
+      @mixin = @viewRowDetail.DetailViewMixins.oc_external
+      @mixin_ctx = $.extend({}, @mixin, {
+        cid: 'cid_ext_pii'
+        $el: $('<div/>')
+        model: @detail
+        rowView: {model: @row}
+        Templates: @viewRowDetail.Templates
+      })
+    afterEach ->
+      window.xlfHideWarnings = false
+
+    it 'html() renders a Contact Data Type <select> for a PII item', ->
+      result = @mixin_ctx.html()
+      expect(result.indexOf('<select')).not.toBe(-1)
+      expect(result.indexOf('contact-data-type')).not.toBe(-1)
+
+    it 'html() renders "Contact Data Type" label for a PII item', ->
+      result = @mixin_ctx.html()
+      expect(result.indexOf('Contact Data Type')).not.toBe(-1)
+
+    it 'html() renders a settings__input container for a PII item', ->
+      result = @mixin_ctx.html()
+      expect(result.indexOf('settings__input')).not.toBe(-1)
+
+    it 'html() does NOT render "Use External Value" label for a PII item', ->
+      result = @mixin_ctx.html()
+      expect(result.indexOf('Use External Value')).toBe(-1)
+
+    it 'html() still renders <select> for a text item with empty bind::oc:external', ->
+      @detail.set('value', '')
+      result = @mixin_ctx.html()
+      expect(result.indexOf('<select')).not.toBe(-1)
+
+    it 'html() still renders "Use External Value" label for non-PII text item', ->
+      @detail.set('value', '')
+      result = @mixin_ctx.html()
+      expect(result.indexOf('Use External Value')).not.toBe(-1)


### PR DESCRIPTION
## Checklist

1. [Y] If you've added code that should be tested, add tests
2. [X] If you've changed APIs, update (or create!) the documentation
3. [Y] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

- Remove "Use External Value" field from PII (encrypted) items
- When a PII (Encrypted) item is created or edited, the "Use External Value" field is not shown anywhere in the config panel. However, the value contactdata is still stored in the item definition automatically — so the form publishes and functions correctly as a contact data item.
- A "Contact Data Type" dropdown appears in the config panel, pre-selected to firstname. All 14 contact identifiers are available.
- When the user selects fulldob as the contact data type, the item's underlying data type changes from text to date in the background. This change is reflected in the downloaded XLS file — the type column will show date.

## Related issues
https://github.com/kobotoolbox/docs/issues/538
https://jira.openclinica.com/browse/OC-27687
