### PR TITLE
OC-27873-Enhance eConsent functionality with event type checks and re…

### DIFF
--- a/jsapp/js/components/formBuilder/econsentSignature.ts
+++ b/jsapp/js/components/formBuilder/econsentSignature.ts
@@ -30,26 +30,29 @@ export function isEConsentAllowedEventType(eventType: FormEventType | null | und
 }
 
 /**
+ * Reads a named query parameter from the current URL hash fragment.
+ * Returns null when there are no query params or the name is absent.
+ */
+function getHashQueryParam(name: string): string | null {
+  const hash = window.location.hash;
+  const queryIndex = hash.indexOf('?');
+  if (queryIndex === -1) return null;
+  return new URLSearchParams(hash.slice(queryIndex)).get(name);
+}
+
+/**
  * Read study eConsent module status from the URL query parameter `econsent`.
  */
 export function getStudyEConsentModuleStatus(): string | null {
-  const hash = window.location.hash; // e.g. "#/forms/uid/edit?econsent=ACTIVE"
-  const queryIndex = hash.indexOf('?');
-  if (queryIndex === -1) return null;
-  const params = new URLSearchParams(hash.slice(queryIndex));
-  return params.get('econsent');
+  return getHashQueryParam('econsent');
 }
 
 /**
  * Read the event type for the current form context from the URL query parameter
  * `event_type`. Returns null when the parameter is absent (e.g. Library editing).
  */
-export function getFormEventType(): string | null {
-  const hash = window.location.hash;
-  const queryIndex = hash.indexOf('?');
-  if (queryIndex === -1) return null;
-  const params = new URLSearchParams(hash.slice(queryIndex));
-  return params.get('event_type');
+export function getFormEventType(): FormEventType | null {
+  return getHashQueryParam('event_type');
 }
 
 /**

--- a/jsapp/js/components/formBuilder/econsentSignature.ts
+++ b/jsapp/js/components/formBuilder/econsentSignature.ts
@@ -2,8 +2,31 @@ export const ECONSENT_SIGNATURE_EXTERNAL_VALUE = 'signature' as const;
 
 export type EConsentModuleStatus = 'ACTIVE' | 'PENDING' | string;
 
+/**
+ * Event types for an event-form-definition context.
+ * Only NONREPEATING_VISIT events are eligible for eConsent forms.
+ */
+export type FormEventType =
+  | 'NONREPEATING_VISIT'
+  | 'REPEATING_VISIT'
+  | 'NONREPEATING_COMMON'
+  | 'REPEATING_COMMON'
+  | string;
+
 export function isEConsentEnabledStatus(status: EConsentModuleStatus | null | undefined): boolean {
   return status === 'ACTIVE' || status === 'PENDING';
+}
+
+/**
+ * Returns true only for event types that are eligible to host an eConsent form.
+ * Only non-repeating Visit events qualify; all Common events and Repeating Visit
+ * events are ineligible.
+ */
+export function isEConsentAllowedEventType(eventType: FormEventType | null | undefined): boolean {
+  if (eventType === null || eventType === undefined) {
+    return true;
+  }
+  return eventType === 'NONREPEATING_VISIT';
 }
 
 /**
@@ -18,11 +41,29 @@ export function getStudyEConsentModuleStatus(): string | null {
 }
 
 /**
- * AC2 gating: allow adding new eConsent Signature items only if study module is ACTIVE/PENDING.
- * Existing signature rows should continue to render regardless.
+ * Read the event type for the current form context from the URL query parameter
+ * `event_type`. Returns null when the parameter is absent (e.g. Library editing).
+ */
+export function getFormEventType(): string | null {
+  const hash = window.location.hash;
+  const queryIndex = hash.indexOf('?');
+  if (queryIndex === -1) return null;
+  const params = new URLSearchParams(hash.slice(queryIndex));
+  return params.get('event_type');
+}
+
+/**
+ * Gating for the eConsent Signature item type in Form Designer.
+ * Requires both:
+ *   1. The study eConsent module is ACTIVE or PENDING.
+ *   2. The form is in a Non-Repeating Visit event (or no event context is set).
+ * Existing signature rows continue to render regardless of this check.
  */
 export function isEConsentSignatureItemTypeAllowed(): boolean {
-  return isEConsentEnabledStatus(getStudyEConsentModuleStatus());
+  return (
+    isEConsentEnabledStatus(getStudyEConsentModuleStatus()) &&
+    isEConsentAllowedEventType(getFormEventType())
+  );
 }
 
 /**

--- a/test/xlform/econsentSignature.tests.coffee
+++ b/test/xlform/econsentSignature.tests.coffee
@@ -15,6 +15,86 @@ do ->
         expect(econsentSignature.isEConsentEnabledStatus('INACTIVE')).toBe(false)
         expect(econsentSignature.isEConsentEnabledStatus(null)).toBe(false)
 
+    describe 'isEConsentAllowedEventType', ->
+      it 'returns true for NONREPEATING_VISIT', ->
+        expect(econsentSignature.isEConsentAllowedEventType('NONREPEATING_VISIT')).toBe(true)
+
+      it 'returns false for REPEATING_VISIT', ->
+        expect(econsentSignature.isEConsentAllowedEventType('REPEATING_VISIT')).toBe(false)
+
+      it 'returns false for NONREPEATING_COMMON', ->
+        expect(econsentSignature.isEConsentAllowedEventType('NONREPEATING_COMMON')).toBe(false)
+
+      it 'returns false for REPEATING_COMMON', ->
+        expect(econsentSignature.isEConsentAllowedEventType('REPEATING_COMMON')).toBe(false)
+
+      it 'returns true when event type is null (no event context, e.g. Library editing)', ->
+        expect(econsentSignature.isEConsentAllowedEventType(null)).toBe(true)
+
+      it 'returns true when event type is undefined (no event context)', ->
+        expect(econsentSignature.isEConsentAllowedEventType(undefined)).toBe(true)
+
+    describe 'getFormEventType', ->
+      beforeEach ->
+        # Reset hash before each test
+        window.location.hash = ''
+
+      it 'returns event_type from URL hash query params', ->
+        window.location.hash = '#/forms/uid/edit?econsent=ACTIVE&event_type=NONREPEATING_VISIT'
+        expect(econsentSignature.getFormEventType()).toBe('NONREPEATING_VISIT')
+
+      it 'returns REPEATING_VISIT when set', ->
+        window.location.hash = '#/forms/uid/edit?econsent=ACTIVE&event_type=REPEATING_VISIT'
+        expect(econsentSignature.getFormEventType()).toBe('REPEATING_VISIT')
+
+      it 'returns null when event_type param is absent', ->
+        window.location.hash = '#/forms/uid/edit?econsent=ACTIVE'
+        expect(econsentSignature.getFormEventType()).toBe(null)
+
+      it 'returns null when there are no query params', ->
+        window.location.hash = '#/forms/uid/edit'
+        expect(econsentSignature.getFormEventType()).toBe(null)
+
+    describe 'isEConsentSignatureItemTypeAllowed (combined gating)', ->
+      beforeEach ->
+        window.location.hash = ''
+
+      it 'returns true when econsent is ACTIVE and event type is NONREPEATING_VISIT', ->
+        window.location.hash = '#/forms/uid/edit?econsent=ACTIVE&event_type=NONREPEATING_VISIT'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(true)
+
+      it 'returns true when econsent is PENDING and event type is NONREPEATING_VISIT', ->
+        window.location.hash = '#/forms/uid/edit?econsent=PENDING&event_type=NONREPEATING_VISIT'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(true)
+
+      it 'returns false when econsent is ACTIVE but event type is REPEATING_VISIT', ->
+        window.location.hash = '#/forms/uid/edit?econsent=ACTIVE&event_type=REPEATING_VISIT'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(false)
+
+      it 'returns false when econsent is ACTIVE but event type is NONREPEATING_COMMON', ->
+        window.location.hash = '#/forms/uid/edit?econsent=ACTIVE&event_type=NONREPEATING_COMMON'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(false)
+
+      it 'returns false when econsent is ACTIVE but event type is REPEATING_COMMON', ->
+        window.location.hash = '#/forms/uid/edit?econsent=ACTIVE&event_type=REPEATING_COMMON'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(false)
+
+      it 'returns false when econsent is PENDING but event type is REPEATING_VISIT', ->
+        window.location.hash = '#/forms/uid/edit?econsent=PENDING&event_type=REPEATING_VISIT'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(false)
+
+      it 'returns false when econsent module is not enabled regardless of event type', ->
+        window.location.hash = '#/forms/uid/edit?econsent=INACTIVE&event_type=NONREPEATING_VISIT'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(false)
+
+      it 'returns true when econsent is ACTIVE and no event_type param (Library editing)', ->
+        window.location.hash = '#/forms/uid/edit?econsent=ACTIVE'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(true)
+
+      it 'returns false when econsent is not set even if event type is NONREPEATING_VISIT', ->
+        window.location.hash = '#/forms/uid/edit?event_type=NONREPEATING_VISIT'
+        expect(econsentSignature.isEConsentSignatureItemTypeAllowed()).toBe(false)
+
     describe 'appendEConsentQueryToPath', ->
       it 'appends econsent when status is enabled', ->
         expect(
@@ -51,4 +131,3 @@ do ->
           searchParams: new URLSearchParams('econsent=PENDING')
           navigate: ->
         expect(econsentSignature.getEConsentStatusFromRouter(router)).toBe('PENDING')
-

--- a/test/xlform/econsentSignature.tests.coffee
+++ b/test/xlform/econsentSignature.tests.coffee
@@ -34,6 +34,9 @@ do ->
       it 'returns true when event type is undefined (no event context)', ->
         expect(econsentSignature.isEConsentAllowedEventType(undefined)).toBe(true)
 
+      it 'returns false for an unknown/unrecognised event type value', ->
+        expect(econsentSignature.isEConsentAllowedEventType('SOMETHING_ELSE')).toBe(false)
+
     describe 'getFormEventType', ->
       beforeEach ->
         # Reset hash before each test
@@ -54,6 +57,10 @@ do ->
       it 'returns null when there are no query params', ->
         window.location.hash = '#/forms/uid/edit'
         expect(econsentSignature.getFormEventType()).toBe(null)
+
+      it 'returns empty string when event_type param is present but empty', ->
+        window.location.hash = '#/forms/uid/edit?event_type='
+        expect(econsentSignature.getFormEventType()).toBe('')
 
     describe 'isEConsentSignatureItemTypeAllowed (combined gating)', ->
       beforeEach ->


### PR DESCRIPTION
…lated tests

## Checklist

1. [Y] If you've added code that should be tested, add tests
2. [X] If you've changed APIs, update (or create!) the documentation
3. [Y] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

- The eConsent Signature item type in Form Designer was previously visible in any event context where the study's eConsent module was ACTIVE or PENDING. This ticket adds a second gate: the form must also be opened from a Non-Repeating Visit event.
- Signature item is hidden for Repeating Visit events and all Common events, and visible only for Non-Repeating Visit events (or Library editing where no event context exists).

## Related issues

https://github.com/kobotoolbox/docs/issues/550
https://jira.openclinica.com/browse/OC-27873