### PR TITLE
OC-27878 Replace Appearance Dropdown with Card-Grid Picker for Date I…

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -22,11 +22,11 @@ module.exports = do ->
         return { card: 'month-year', columnCount: null, customText: null }
       if cleaned is 'year'
         return { card: 'year', columnCount: null, customText: null }
-      if cleaned is ''
+      if cleaned is '' or cleaned is 'default'
         return { card: 'full-date', columnCount: null, customText: null }
       if cleaned is 'other'
-        return { card: 'custom', columnCount: null, customText: '' }
-      return { card: 'custom', columnCount: null, customText: cleaned }
+        return { card: 'date-custom', columnCount: null, customText: '' }
+      return { card: 'date-custom', columnCount: null, customText: cleaned }
 
     if cleaned is 'likert'
       if questionType is 'select_one'
@@ -74,6 +74,9 @@ module.exports = do ->
       when 'full-date'   then ''
       when 'month-year'  then 'month-year'
       when 'year'        then 'year'
+      when 'date-custom'
+        text = ((customText or '').trim())
+        if text then text else 'other'
       when 'dropdown'      then 'minimal'
       when 'columns-buttons'
         if columnCount? then "columns-#{columnCount}" else 'columns'
@@ -96,6 +99,8 @@ module.exports = do ->
       when 'full-date'              then t('Full date')
       when 'month-year'             then t('Month & year')
       when 'year'                   then t('Year only')
+      when 'date-custom'
+        if customText then "#{t('Custom')}: #{customText}" else t('Custom')
       when 'dropdown'               then t('Dropdown')
       when 'image-grid'             then t('Image grid')
       when 'image-grid-labels-only' then t('Image grid (labels only)')
@@ -898,6 +903,7 @@ module.exports = do ->
     'search': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="10" width="46" height="14" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="14" width="26" height="5" rx="1.5" fill="#444" opacity="0.15"/><circle cx="40" cy="17" r="3.5" stroke="#444" stroke-width="1.2"/><line x1="43" y1="20" x2="46" y2="23" stroke="#444" stroke-width="1.3"/></svg>'
     'hotspot-image': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="2" y="2" width="48" height="30" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="28" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="7" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/><rect x="22" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/></svg>'
     'custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><path d="M12 8 Q6 8 6 14 L6 20 Q6 26 12 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M40 8 Q46 8 46 14 L46 20 Q46 26 40 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><text x="17" y="22" font-size="12" fill="#378ADD" font-family="Menlo, Consolas, monospace" font-weight="700">&lt;/&gt;</text></svg>'
+    'date-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'full-date': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="2" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="11" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">DD</text><rect x="27" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="52" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="61" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
     'month-year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="10" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="20" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="42" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="52" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
     'year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="20" y="14" width="32" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
@@ -929,8 +935,8 @@ module.exports = do ->
     date = [
       { slug: 'full-date',  label: t('Full date') }
       { slug: 'month-year', label: t('Month & year') }
-      { slug: 'year',       label: t('Year only') }
-      { slug: 'custom',     label: t('Custom') }
+      { slug: 'year',        label: t('Year only') }
+      { slug: 'date-custom', label: t('Custom') }
     ]
     if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
 
@@ -1082,7 +1088,7 @@ module.exports = do ->
         slug = $(evt.currentTarget).data('card-slug')
         @_card = slug
         @_columnCount = null unless @_card in ['columns-buttons', 'columns-labels-only']
-        @_customText = null unless @_card is 'custom'
+        @_customText = null unless @_card in ['custom', 'date-custom']
         @$el.find('.appearance-card').removeClass('is-selected')
         $(evt.currentTarget).addClass('is-selected')
         @_renderSecondaryControl(questionType)
@@ -1150,7 +1156,7 @@ module.exports = do ->
           $ctrl.find('.appearance-columns-control__hint code').text(hintVal)
           @_writeModelValue()
 
-      else if @_card is 'custom'
+      else if @_card in ['custom', 'date-custom']
         existingText = @_customText or ''
         $input = $('<input/>', {
           type: 'text'

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -16,6 +16,18 @@ module.exports = do ->
   parseAppearanceValue = (value, questionType) ->
     cleaned = ((value or '').trim().replace(/\s*\bw\d+\b\s*/g, ' ')).trim()
 
+    # Date-specific card grid
+    if questionType is 'date'
+      if cleaned is 'month-year'
+        return { card: 'month-year', columnCount: null, customText: null }
+      if cleaned is 'year'
+        return { card: 'year', columnCount: null, customText: null }
+      if cleaned is ''
+        return { card: 'full-date', columnCount: null, customText: null }
+      if cleaned is 'other'
+        return { card: 'custom', columnCount: null, customText: '' }
+      return { card: 'custom', columnCount: null, customText: cleaned }
+
     if cleaned is 'likert'
       if questionType is 'select_one'
         return { card: 'likert-scale', columnCount: null, customText: null }
@@ -59,6 +71,9 @@ module.exports = do ->
   buildModelValue = (card, columnCount, customText) ->
     switch card
       when 'radio-list', 'checkbox-list' then ''
+      when 'full-date'   then ''
+      when 'month-year'  then 'month-year'
+      when 'year'        then 'year'
       when 'dropdown'      then 'minimal'
       when 'columns-buttons'
         if columnCount? then "columns-#{columnCount}" else 'columns'
@@ -78,6 +93,9 @@ module.exports = do ->
     switch card
       when 'radio-list'             then t('Radio list')
       when 'checkbox-list'          then t('Checkbox list')
+      when 'full-date'              then t('Full date')
+      when 'month-year'             then t('Month & year')
+      when 'year'                   then t('Year only')
       when 'dropdown'               then t('Dropdown')
       when 'image-grid'             then t('Image grid')
       when 'image-grid-labels-only' then t('Image grid (labels only)')
@@ -880,6 +898,9 @@ module.exports = do ->
     'search': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="10" width="46" height="14" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="14" width="26" height="5" rx="1.5" fill="#444" opacity="0.15"/><circle cx="40" cy="17" r="3.5" stroke="#444" stroke-width="1.2"/><line x1="43" y1="20" x2="46" y2="23" stroke="#444" stroke-width="1.3"/></svg>'
     'hotspot-image': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="2" y="2" width="48" height="30" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="28" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="7" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/><rect x="22" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/></svg>'
     'custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><path d="M12 8 Q6 8 6 14 L6 20 Q6 26 12 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M40 8 Q46 8 46 14 L46 20 Q46 26 40 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><text x="17" y="22" font-size="12" fill="#378ADD" font-family="Menlo, Consolas, monospace" font-weight="700">&lt;/&gt;</text></svg>'
+    'full-date': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="2" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="11" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">DD</text><rect x="27" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="52" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="61" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
+    'month-year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="10" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="20" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="42" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="52" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
+    'year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="20" y="14" width="32" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
 
   getAppearanceCards = (questionType) ->
     select_one = [
@@ -905,11 +926,17 @@ module.exports = do ->
       { slug: 'hotspot-image',          label: t('Hotspot image') }
       { slug: 'custom',                 label: t('Custom') }
     ]
-    if questionType is 'select_multiple' then select_multiple else select_one
+    date = [
+      { slug: 'full-date',  label: t('Full date') }
+      { slug: 'month-year', label: t('Month & year') }
+      { slug: 'year',       label: t('Year only') }
+      { slug: 'custom',     label: t('Custom') }
+    ]
+    if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
 
   viewRowDetail.DetailViewMixins.appearance =
     isCardGridType: ->
-      @model_type() in ['select_one', 'select_multiple']
+      @model_type() in ['select_one', 'select_multiple', 'date']
 
     getTypes: ->
       types =

--- a/test/xlform/questionTypeForms.tests.coffee
+++ b/test/xlform/questionTypeForms.tests.coffee
@@ -143,11 +143,10 @@ do ->
       expect(result.indexOf('draw')).not.toBe(-1)
       expect(result.indexOf('signature')).not.toBe(-1)
 
-    it 'date html() renders a dropdown with month-year, year', ->
+    it 'date html() returns empty string (card grid path, no legacy dropdown)', ->
       ctx = buildAppearanceMixinCtx('date')
       result = ctx.html()
-      expect(result.indexOf('<select')).not.toBe(-1)
-      expect(result.indexOf('month-year')).not.toBe(-1)
+      expect(result).toBe('')
 
     it 'integer html() renders a dropdown with analog-scale options', ->
       ctx = buildAppearanceMixinCtx('integer')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -541,6 +541,12 @@ do ->
     it 'year → "Year only"', ->
       expect(buildPillText('year', null, null)).toBe('Year only')
 
+    it 'date-custom with text → "Custom: compact"', ->
+      expect(buildPillText('date-custom', null, 'compact')).toBe('Custom: compact')
+
+    it 'date-custom with no text → "Custom"', ->
+      expect(buildPillText('date-custom', null, null)).toBe('Custom')
+
   ###############################################################
   # appearance picker: parseAppearanceValue — date type
   ###############################################################
@@ -559,11 +565,14 @@ do ->
     it 'year → year card for date', ->
       expect(parseAppearanceValue('year', 'date')).toEqual { card: 'year', columnCount: null, customText: null }
 
-    it 'unknown value → custom for date', ->
-      expect(parseAppearanceValue('compact', 'date')).toEqual { card: 'custom', columnCount: null, customText: 'compact' }
+    it 'unknown value → date-custom for date', ->
+      expect(parseAppearanceValue('compact', 'date')).toEqual { card: 'date-custom', columnCount: null, customText: 'compact' }
 
-    it '"other" → custom with empty text for date', ->
-      expect(parseAppearanceValue('other', 'date')).toEqual { card: 'custom', columnCount: null, customText: '' }
+    it '"other" → date-custom with empty text for date', ->
+      expect(parseAppearanceValue('other', 'date')).toEqual { card: 'date-custom', columnCount: null, customText: '' }
+
+    it '"default" → full-date for date (legacy value treated as default)', ->
+      expect(parseAppearanceValue('default', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
 
     it 'width token stripped before date parse', ->
       expect(parseAppearanceValue('month-year w3', 'date')).toEqual { card: 'month-year', columnCount: null, customText: null }
@@ -585,3 +594,12 @@ do ->
 
     it 'year → "year"', ->
       expect(buildModelValue('year', null, null)).toBe('year')
+
+    it 'date-custom with text → raw text', ->
+      expect(buildModelValue('date-custom', null, 'compact')).toBe('compact')
+
+    it 'date-custom with empty text → "other"', ->
+      expect(buildModelValue('date-custom', null, '')).toBe('other')
+
+    it 'date-custom with null text → "other"', ->
+      expect(buildModelValue('date-custom', null, null)).toBe('other')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -531,3 +531,57 @@ do ->
 
     it 'custom with no text → "Custom"', ->
       expect(buildPillText('custom', null, null)).toBe('Custom')
+
+    it 'full-date → "Full date"', ->
+      expect(buildPillText('full-date', null, null)).toBe('Full date')
+
+    it 'month-year → "Month & year"', ->
+      expect(buildPillText('month-year', null, null)).toBe('Month & year')
+
+    it 'year → "Year only"', ->
+      expect(buildPillText('year', null, null)).toBe('Year only')
+
+  ###############################################################
+  # appearance picker: parseAppearanceValue — date type
+  ###############################################################
+  describe 'parseAppearanceValue (date)', ->
+    {parseAppearanceValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'empty string → full-date for date', ->
+      expect(parseAppearanceValue('', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
+
+    it 'null → full-date for date', ->
+      expect(parseAppearanceValue(null, 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
+
+    it 'month-year → month-year card for date', ->
+      expect(parseAppearanceValue('month-year', 'date')).toEqual { card: 'month-year', columnCount: null, customText: null }
+
+    it 'year → year card for date', ->
+      expect(parseAppearanceValue('year', 'date')).toEqual { card: 'year', columnCount: null, customText: null }
+
+    it 'unknown value → custom for date', ->
+      expect(parseAppearanceValue('compact', 'date')).toEqual { card: 'custom', columnCount: null, customText: 'compact' }
+
+    it '"other" → custom with empty text for date', ->
+      expect(parseAppearanceValue('other', 'date')).toEqual { card: 'custom', columnCount: null, customText: '' }
+
+    it 'width token stripped before date parse', ->
+      expect(parseAppearanceValue('month-year w3', 'date')).toEqual { card: 'month-year', columnCount: null, customText: null }
+
+    it 'width-only → full-date for date', ->
+      expect(parseAppearanceValue('w3', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
+
+  ###############################################################
+  # appearance picker: buildModelValue — date cards
+  ###############################################################
+  describe 'buildModelValue (date cards)', ->
+    {buildModelValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'full-date → empty string', ->
+      expect(buildModelValue('full-date', null, null)).toBe('')
+
+    it 'month-year → "month-year"', ->
+      expect(buildModelValue('month-year', null, null)).toBe('month-year')
+
+    it 'year → "year"', ->
+      expect(buildModelValue('year', null, null)).toBe('year')


### PR DESCRIPTION
…tems

### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Replaces the legacy Appearance dropdown for Date items with a collapsible card-grid picker that provides four options:

Full Date (default)
Month & Year
Year Only
Custom
Each option is displayed as a card with an SVG icon and is mapped to its corresponding XForm appearance value.

Related issues
https://jira.openclinica.com/browse/OC-27878
https://github.com/kobotoolbox/docs/issues/552

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
