### PR TITLE
OC-27710 Card-Grid Picker for Text Items Appearance

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1097,7 +1097,8 @@ module.exports = do ->
       $pill    = $section.find('.js-appearance-pill').eq(0)
       $toggle  = $section.find('.js-appearance-toggle').eq(0)
 
-      # Build card grid
+      # Build card grid — clear any prior grid before re-rendering
+      @$el.find('.card__settings__appearance-grid').remove()
       cards = getAppearanceCards(questionType)
       cardHtml = ''
       for cardDef in cards
@@ -1125,8 +1126,8 @@ module.exports = do ->
         @$select_width.val(width_val) if width_val?
         @$select_width.on 'change', => @_writeModelValue()
 
-      # Card click
-      @$el.on 'click', '.appearance-card', (evt) =>
+      # Card click — namespace so re-renders don't stack handlers
+      @$el.off('click.oc-appearance').on 'click.oc-appearance', '.appearance-card', (evt) =>
         slug = $(evt.currentTarget).data('card-slug')
         @_card = slug
         @_columnCount = null unless @_card in ['columns-buttons', 'columns-labels-only']

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -32,6 +32,16 @@ module.exports = do ->
         return { card: 'note-custom', columnCount: null, customText: '' }
       return { card: 'note-custom', columnCount: null, customText: cleaned }
 
+    # Text-specific card grid
+    if questionType is 'text'
+      if cleaned is '' or cleaned is 'default'
+        return { card: 'single-line', columnCount: null, customText: null }
+      if cleaned is 'multiline'
+        return { card: 'paragraph', columnCount: null, customText: null }
+      if cleaned is 'other'
+        return { card: 'custom', columnCount: null, customText: '' }
+      return { card: 'custom', columnCount: null, customText: cleaned }
+
     # Date-specific card grid
     if questionType is 'date'
       if cleaned is 'month-year'
@@ -87,6 +97,8 @@ module.exports = do ->
   buildModelValue = (card, columnCount, customText) ->
     switch card
       when 'radio-list', 'checkbox-list' then ''
+      when 'single-line' then ''
+      when 'paragraph'   then 'multiline'
       when 'file'        then ''
       when 'file-custom'
         text = ((customText or '').trim())
@@ -120,6 +132,8 @@ module.exports = do ->
     switch card
       when 'radio-list'             then t('Radio list')
       when 'checkbox-list'          then t('Checkbox list')
+      when 'single-line'            then t('Single line')
+      when 'paragraph'              then t('Paragraph')
       when 'file'                   then t('File upload')
       when 'file-custom'
         if customText then "#{t('Custom')}: #{customText}" else t('Custom')
@@ -932,6 +946,8 @@ module.exports = do ->
     'likert-scale': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><line x1="5" y1="17" x2="47" y2="17" stroke="#444" stroke-width="1.2"/><circle cx="5" cy="17" r="3" stroke="#444" stroke-width="1.2"/><circle cx="16" cy="17" r="3" stroke="#444" stroke-width="1.2"/><circle cx="26" cy="17" r="3" stroke="#444" stroke-width="1.2"/><circle cx="36" cy="17" r="3" stroke="#444" stroke-width="1.2"/><circle cx="47" cy="17" r="3" stroke="#444" stroke-width="1.2"/></svg>'
     'search': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="10" width="46" height="14" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="14" width="26" height="5" rx="1.5" fill="#444" opacity="0.15"/><circle cx="40" cy="17" r="3.5" stroke="#444" stroke-width="1.2"/><line x1="43" y1="20" x2="46" y2="23" stroke="#444" stroke-width="1.3"/></svg>'
     'hotspot-image': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="2" y="2" width="48" height="30" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="28" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="7" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/><rect x="22" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/></svg>'
+    'single-line': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="11" width="46" height="12" rx="2" stroke="#444" stroke-width="1.3"/><text x="8" y="20" font-size="9" fill="#444" font-family="Arial, sans-serif" font-weight="700">abc</text><line x1="24" y1="14" x2="24" y2="21" stroke="#378ADD" stroke-width="1.2"/></svg>'
+    'paragraph': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="3" width="46" height="28" rx="2" stroke="#444" stroke-width="1.3"/><line x1="7" y1="10" x2="42" y2="10" stroke="#444" stroke-width="1.1" opacity="0.5"/><line x1="7" y1="16" x2="45" y2="16" stroke="#444" stroke-width="1.1" opacity="0.5"/><line x1="7" y1="22" x2="38" y2="22" stroke="#444" stroke-width="1.1" opacity="0.5"/><path d="M44 27 L48 27 L48 31" stroke="#444" stroke-width="1.1" fill="none"/></svg>'
     'custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><path d="M12 8 Q6 8 6 14 L6 20 Q6 26 12 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M40 8 Q46 8 46 14 L46 20 Q46 26 40 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><text x="17" y="22" font-size="12" fill="#378ADD" font-family="Menlo, Consolas, monospace" font-weight="700">&lt;/&gt;</text></svg>'
     'date-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'file': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><path d="M17 4 L17 40 L55 40 L55 14 L45 4 Z" stroke="#888" stroke-width="1.3"/><path d="M45 4 L45 14 L55 14" stroke="#888" stroke-width="1.1" fill="none"/><line x1="36" y1="33" x2="36" y2="22" stroke="#888" stroke-width="1.4" stroke-linecap="round"/><path d="M31 27 L36 22 L41 27" stroke="#888" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>'
@@ -980,15 +996,19 @@ module.exports = do ->
       { slug: 'file',        label: t('File upload') }
       { slug: 'file-custom', label: t('Custom') }
     ]
-    if questionType is 'file' then file else if questionType is 'note' then note else if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
+    text = [
+      { slug: 'single-line', label: t('Single line') }
+      { slug: 'paragraph',   label: t('Paragraph') }
+      { slug: 'custom',      label: t('Custom') }
+    ]
+    if questionType is 'text' then text else if questionType is 'file' then file else if questionType is 'note' then note else if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
 
   viewRowDetail.DetailViewMixins.appearance =
     isCardGridType: ->
-      @model_type() in ['select_one', 'select_multiple', 'date', 'note', 'file']
+      @model_type() in ['select_one', 'select_multiple', 'date', 'note', 'file', 'text']
 
     getTypes: ->
       types =
-        text: ['multiline']
         image: ['draw', 'annotate', 'signature']
         date: ['month-year', 'year']
         integer: ['analog-scale horizontal', 'analog-scale horizontal no-ticks', 'analog-scale vertical', 'analog-scale vertical no-ticks', 'analog-scale vertical show-scale']

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -22,11 +22,11 @@ module.exports = do ->
         return { card: 'month-year', columnCount: null, customText: null }
       if cleaned is 'year'
         return { card: 'year', columnCount: null, customText: null }
-      if cleaned is ''
+      if cleaned is '' or cleaned is 'default'
         return { card: 'full-date', columnCount: null, customText: null }
       if cleaned is 'other'
-        return { card: 'custom', columnCount: null, customText: '' }
-      return { card: 'custom', columnCount: null, customText: cleaned }
+        return { card: 'date-custom', columnCount: null, customText: '' }
+      return { card: 'date-custom', columnCount: null, customText: cleaned }
 
     if cleaned is 'likert'
       if questionType is 'select_one'
@@ -74,6 +74,9 @@ module.exports = do ->
       when 'full-date'   then ''
       when 'month-year'  then 'month-year'
       when 'year'        then 'year'
+      when 'date-custom'
+        text = ((customText or '').trim())
+        if text then text else 'other'
       when 'dropdown'      then 'minimal'
       when 'columns-buttons'
         if columnCount? then "columns-#{columnCount}" else 'columns'
@@ -96,6 +99,8 @@ module.exports = do ->
       when 'full-date'              then t('Full date')
       when 'month-year'             then t('Month & year')
       when 'year'                   then t('Year only')
+      when 'date-custom'
+        if customText then "#{t('Custom')}: #{customText}" else t('Custom')
       when 'dropdown'               then t('Dropdown')
       when 'image-grid'             then t('Image grid')
       when 'image-grid-labels-only' then t('Image grid (labels only)')
@@ -898,6 +903,7 @@ module.exports = do ->
     'search': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="10" width="46" height="14" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="14" width="26" height="5" rx="1.5" fill="#444" opacity="0.15"/><circle cx="40" cy="17" r="3.5" stroke="#444" stroke-width="1.2"/><line x1="43" y1="20" x2="46" y2="23" stroke="#444" stroke-width="1.3"/></svg>'
     'hotspot-image': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="2" y="2" width="48" height="30" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="28" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="7" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/><rect x="22" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/></svg>'
     'custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><path d="M12 8 Q6 8 6 14 L6 20 Q6 26 12 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M40 8 Q46 8 46 14 L46 20 Q46 26 40 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><text x="17" y="22" font-size="12" fill="#378ADD" font-family="Menlo, Consolas, monospace" font-weight="700">&lt;/&gt;</text></svg>'
+    'date-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'full-date': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="2" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="11" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">DD</text><rect x="27" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="52" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="61" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
     'month-year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="10" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="20" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="42" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="52" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
     'year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="20" y="14" width="32" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
@@ -929,8 +935,8 @@ module.exports = do ->
     date = [
       { slug: 'full-date',  label: t('Full date') }
       { slug: 'month-year', label: t('Month & year') }
-      { slug: 'year',       label: t('Year only') }
-      { slug: 'custom',     label: t('Custom') }
+      { slug: 'year',        label: t('Year only') }
+      { slug: 'date-custom', label: t('Custom') }
     ]
     if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
 
@@ -1082,7 +1088,7 @@ module.exports = do ->
         slug = $(evt.currentTarget).data('card-slug')
         @_card = slug
         @_columnCount = null unless @_card in ['columns-buttons', 'columns-labels-only']
-        @_customText = null unless @_card is 'custom'
+        @_customText = null unless @_card in ['custom', 'date-custom']
         @$el.find('.appearance-card').removeClass('is-selected')
         $(evt.currentTarget).addClass('is-selected')
         @_renderSecondaryControl(questionType)
@@ -1150,7 +1156,7 @@ module.exports = do ->
           $ctrl.find('.appearance-columns-control__hint code').text(hintVal)
           @_writeModelValue()
 
-      else if @_card is 'custom'
+      else if @_card in ['custom', 'date-custom']
         existingText = @_customText or ''
         $input = $('<input/>', {
           type: 'text'

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -16,6 +16,14 @@ module.exports = do ->
   parseAppearanceValue = (value, questionType) ->
     cleaned = ((value or '').trim().replace(/\s*\bw\d+\b\s*/g, ' ')).trim()
 
+    # File-specific card grid
+    if questionType is 'file'
+      if cleaned is '' or cleaned is 'default'
+        return { card: 'file', columnCount: null, customText: null }
+      if cleaned is 'other'
+        return { card: 'file-custom', columnCount: null, customText: '' }
+      return { card: 'file-custom', columnCount: null, customText: cleaned }
+
     # Note-specific card grid
     if questionType is 'note'
       if cleaned is '' or cleaned is 'default'
@@ -79,6 +87,10 @@ module.exports = do ->
   buildModelValue = (card, columnCount, customText) ->
     switch card
       when 'radio-list', 'checkbox-list' then ''
+      when 'file'        then ''
+      when 'file-custom'
+        text = ((customText or '').trim())
+        if text then text else 'other'
       when 'note'        then ''
       when 'note-custom'
         text = ((customText or '').trim())
@@ -108,6 +120,9 @@ module.exports = do ->
     switch card
       when 'radio-list'             then t('Radio list')
       when 'checkbox-list'          then t('Checkbox list')
+      when 'file'                   then t('File upload')
+      when 'file-custom'
+        if customText then "#{t('Custom')}: #{customText}" else t('Custom')
       when 'note'                   then t('Note')
       when 'note-custom'
         if customText then "#{t('Custom')}: #{customText}" else t('Custom')
@@ -919,6 +934,8 @@ module.exports = do ->
     'hotspot-image': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="2" y="2" width="48" height="30" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="28" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="7" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/><rect x="22" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/></svg>'
     'custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><path d="M12 8 Q6 8 6 14 L6 20 Q6 26 12 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M40 8 Q46 8 46 14 L46 20 Q46 26 40 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><text x="17" y="22" font-size="12" fill="#378ADD" font-family="Menlo, Consolas, monospace" font-weight="700">&lt;/&gt;</text></svg>'
     'date-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
+    'file': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><path d="M17 4 L17 40 L55 40 L55 14 L45 4 Z" stroke="#888" stroke-width="1.3"/><path d="M45 4 L45 14 L55 14" stroke="#888" stroke-width="1.1" fill="none"/><line x1="36" y1="33" x2="36" y2="22" stroke="#888" stroke-width="1.4" stroke-linecap="round"/><path d="M31 27 L36 22 L41 27" stroke="#888" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+    'file-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'note': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="6" width="56" height="32" rx="3" stroke="#888" stroke-width="1.2"/><rect x="14" y="13" width="44" height="4" rx="1" fill="#888" fill-opacity="0.22"/><rect x="14" y="21" width="36" height="4" rx="1" fill="#888" fill-opacity="0.22"/><rect x="14" y="29" width="26" height="4" rx="1" fill="#888" fill-opacity="0.22"/></svg>'
     'note-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'full-date': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="2" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="11" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">DD</text><rect x="27" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="52" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="61" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
@@ -959,11 +976,15 @@ module.exports = do ->
       { slug: 'note',        label: t('Note') }
       { slug: 'note-custom', label: t('Custom') }
     ]
-    if questionType is 'note' then note else if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
+    file = [
+      { slug: 'file',        label: t('File upload') }
+      { slug: 'file-custom', label: t('Custom') }
+    ]
+    if questionType is 'file' then file else if questionType is 'note' then note else if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
 
   viewRowDetail.DetailViewMixins.appearance =
     isCardGridType: ->
-      @model_type() in ['select_one', 'select_multiple', 'date', 'note']
+      @model_type() in ['select_one', 'select_multiple', 'date', 'note', 'file']
 
     getTypes: ->
       types =
@@ -1109,7 +1130,7 @@ module.exports = do ->
         slug = $(evt.currentTarget).data('card-slug')
         @_card = slug
         @_columnCount = null unless @_card in ['columns-buttons', 'columns-labels-only']
-        @_customText = null unless @_card in ['custom', 'date-custom', 'note-custom']
+        @_customText = null unless @_card in ['custom', 'date-custom', 'note-custom', 'file-custom']
         @$el.find('.appearance-card').removeClass('is-selected')
         $(evt.currentTarget).addClass('is-selected')
         @_renderSecondaryControl(questionType)
@@ -1177,7 +1198,7 @@ module.exports = do ->
           $ctrl.find('.appearance-columns-control__hint code').text(hintVal)
           @_writeModelValue()
 
-      else if @_card in ['custom', 'date-custom', 'note-custom']
+      else if @_card in ['custom', 'date-custom', 'note-custom', 'file-custom']
         existingText = @_customText or ''
         $input = $('<input/>', {
           type: 'text'

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -16,6 +16,18 @@ module.exports = do ->
   parseAppearanceValue = (value, questionType) ->
     cleaned = ((value or '').trim().replace(/\s*\bw\d+\b\s*/g, ' ')).trim()
 
+    # Date-specific card grid
+    if questionType is 'date'
+      if cleaned is 'month-year'
+        return { card: 'month-year', columnCount: null, customText: null }
+      if cleaned is 'year'
+        return { card: 'year', columnCount: null, customText: null }
+      if cleaned is ''
+        return { card: 'full-date', columnCount: null, customText: null }
+      if cleaned is 'other'
+        return { card: 'custom', columnCount: null, customText: '' }
+      return { card: 'custom', columnCount: null, customText: cleaned }
+
     if cleaned is 'likert'
       if questionType is 'select_one'
         return { card: 'likert-scale', columnCount: null, customText: null }
@@ -59,6 +71,9 @@ module.exports = do ->
   buildModelValue = (card, columnCount, customText) ->
     switch card
       when 'radio-list', 'checkbox-list' then ''
+      when 'full-date'   then ''
+      when 'month-year'  then 'month-year'
+      when 'year'        then 'year'
       when 'dropdown'      then 'minimal'
       when 'columns-buttons'
         if columnCount? then "columns-#{columnCount}" else 'columns'
@@ -78,6 +93,9 @@ module.exports = do ->
     switch card
       when 'radio-list'             then t('Radio list')
       when 'checkbox-list'          then t('Checkbox list')
+      when 'full-date'              then t('Full date')
+      when 'month-year'             then t('Month & year')
+      when 'year'                   then t('Year only')
       when 'dropdown'               then t('Dropdown')
       when 'image-grid'             then t('Image grid')
       when 'image-grid-labels-only' then t('Image grid (labels only)')
@@ -880,6 +898,9 @@ module.exports = do ->
     'search': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="10" width="46" height="14" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="14" width="26" height="5" rx="1.5" fill="#444" opacity="0.15"/><circle cx="40" cy="17" r="3.5" stroke="#444" stroke-width="1.2"/><line x1="43" y1="20" x2="46" y2="23" stroke="#444" stroke-width="1.3"/></svg>'
     'hotspot-image': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="2" y="2" width="48" height="30" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="28" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="7" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/><rect x="22" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/></svg>'
     'custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><path d="M12 8 Q6 8 6 14 L6 20 Q6 26 12 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M40 8 Q46 8 46 14 L46 20 Q46 26 40 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><text x="17" y="22" font-size="12" fill="#378ADD" font-family="Menlo, Consolas, monospace" font-weight="700">&lt;/&gt;</text></svg>'
+    'full-date': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="2" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="11" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">DD</text><rect x="27" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="52" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="61" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
+    'month-year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="10" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="20" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="42" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="52" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
+    'year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="20" y="14" width="32" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
 
   getAppearanceCards = (questionType) ->
     select_one = [
@@ -905,11 +926,17 @@ module.exports = do ->
       { slug: 'hotspot-image',          label: t('Hotspot image') }
       { slug: 'custom',                 label: t('Custom') }
     ]
-    if questionType is 'select_multiple' then select_multiple else select_one
+    date = [
+      { slug: 'full-date',  label: t('Full date') }
+      { slug: 'month-year', label: t('Month & year') }
+      { slug: 'year',       label: t('Year only') }
+      { slug: 'custom',     label: t('Custom') }
+    ]
+    if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
 
   viewRowDetail.DetailViewMixins.appearance =
     isCardGridType: ->
-      @model_type() in ['select_one', 'select_multiple']
+      @model_type() in ['select_one', 'select_multiple', 'date']
 
     getTypes: ->
       types =

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1124,7 +1124,7 @@ module.exports = do ->
       for cardDef in cards
         selected = if cardDef.slug is card then ' is-selected' else ''
         cardHtml += """
-          <div class="appearance-card#{selected}" data-card-slug="#{cardDef.slug}">
+          <div class="appearance-card#{selected}" data-card-slug="#{cardDef.slug}" role="button" tabindex="0" aria-pressed="#{if cardDef.slug is card then 'true' else 'false'}">
             <div class="appearance-card__icon">#{APPEARANCE_ICONS[cardDef.slug]}</div>
             <div class="appearance-card__label">#{cardDef.label}</div>
           </div>
@@ -1146,16 +1146,20 @@ module.exports = do ->
         @$select_width.val(width_val) if width_val?
         @$select_width.on 'change', => @_writeModelValue()
 
-      # Card click — namespace so re-renders don't stack handlers
-      @$el.off('click.oc-appearance').on 'click.oc-appearance', '.appearance-card', (evt) =>
-        slug = $(evt.currentTarget).data('card-slug')
+      # Card click/keyboard — namespace so re-renders don't stack handlers
+      selectCard = (el) =>
+        slug = $(el).data('card-slug')
         @_card = slug
         @_columnCount = null unless @_card in ['columns-buttons', 'columns-labels-only']
         @_customText = null unless @_card in ['custom', 'date-custom', 'note-custom', 'file-custom']
-        @$el.find('.appearance-card').removeClass('is-selected')
-        $(evt.currentTarget).addClass('is-selected')
+        @$el.find('.appearance-card').removeClass('is-selected').attr('aria-pressed', 'false')
+        $(el).addClass('is-selected').attr('aria-pressed', 'true')
         @_renderSecondaryControl(questionType)
         @_writeModelValue()
+      @$el.off('click.oc-appearance').on 'click.oc-appearance', '.appearance-card', (evt) =>
+        selectCard(evt.currentTarget)
+      @$el.off('keydown.oc-appearance').on 'keydown.oc-appearance', '.appearance-card', (evt) =>
+        selectCard(evt.currentTarget) if evt.key in ['Enter', ' ']
 
       # Initial pill (section starts collapsed)
       @_refreshPill($pill)

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -16,6 +16,14 @@ module.exports = do ->
   parseAppearanceValue = (value, questionType) ->
     cleaned = ((value or '').trim().replace(/\s*\bw\d+\b\s*/g, ' ')).trim()
 
+    # Note-specific card grid
+    if questionType is 'note'
+      if cleaned is '' or cleaned is 'default'
+        return { card: 'note', columnCount: null, customText: null }
+      if cleaned is 'other'
+        return { card: 'note-custom', columnCount: null, customText: '' }
+      return { card: 'note-custom', columnCount: null, customText: cleaned }
+
     # Date-specific card grid
     if questionType is 'date'
       if cleaned is 'month-year'
@@ -71,6 +79,10 @@ module.exports = do ->
   buildModelValue = (card, columnCount, customText) ->
     switch card
       when 'radio-list', 'checkbox-list' then ''
+      when 'note'        then ''
+      when 'note-custom'
+        text = ((customText or '').trim())
+        if text then text else 'other'
       when 'full-date'   then ''
       when 'month-year'  then 'month-year'
       when 'year'        then 'year'
@@ -96,6 +108,9 @@ module.exports = do ->
     switch card
       when 'radio-list'             then t('Radio list')
       when 'checkbox-list'          then t('Checkbox list')
+      when 'note'                   then t('Note')
+      when 'note-custom'
+        if customText then "#{t('Custom')}: #{customText}" else t('Custom')
       when 'full-date'              then t('Full date')
       when 'month-year'             then t('Month & year')
       when 'year'                   then t('Year only')
@@ -904,6 +919,8 @@ module.exports = do ->
     'hotspot-image': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="2" y="2" width="48" height="30" rx="3" stroke="#444" stroke-width="1.2"/><rect x="7" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="28" y="6" width="16" height="11" rx="2" stroke="#444" stroke-width="1.1"/><rect x="7" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/><rect x="22" y="20" width="12" height="8" rx="2" stroke="#444" stroke-width="1.1"/></svg>'
     'custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><path d="M12 8 Q6 8 6 14 L6 20 Q6 26 12 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M40 8 Q46 8 46 14 L46 20 Q46 26 40 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><text x="17" y="22" font-size="12" fill="#378ADD" font-family="Menlo, Consolas, monospace" font-weight="700">&lt;/&gt;</text></svg>'
     'date-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
+    'note': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="6" width="56" height="32" rx="3" stroke="#888" stroke-width="1.2"/><rect x="14" y="13" width="44" height="4" rx="1" fill="#888" fill-opacity="0.22"/><rect x="14" y="21" width="36" height="4" rx="1" fill="#888" fill-opacity="0.22"/><rect x="14" y="29" width="26" height="4" rx="1" fill="#888" fill-opacity="0.22"/></svg>'
+    'note-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'full-date': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="2" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="11" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">DD</text><rect x="27" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="52" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="61" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
     'month-year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="10" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="20" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="42" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="52" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
     'year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="20" y="14" width="32" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
@@ -938,11 +955,15 @@ module.exports = do ->
       { slug: 'year',        label: t('Year only') }
       { slug: 'date-custom', label: t('Custom') }
     ]
-    if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
+    note = [
+      { slug: 'note',        label: t('Note') }
+      { slug: 'note-custom', label: t('Custom') }
+    ]
+    if questionType is 'note' then note else if questionType is 'date' then date else if questionType is 'select_multiple' then select_multiple else select_one
 
   viewRowDetail.DetailViewMixins.appearance =
     isCardGridType: ->
-      @model_type() in ['select_one', 'select_multiple', 'date']
+      @model_type() in ['select_one', 'select_multiple', 'date', 'note']
 
     getTypes: ->
       types =
@@ -1088,7 +1109,7 @@ module.exports = do ->
         slug = $(evt.currentTarget).data('card-slug')
         @_card = slug
         @_columnCount = null unless @_card in ['columns-buttons', 'columns-labels-only']
-        @_customText = null unless @_card in ['custom', 'date-custom']
+        @_customText = null unless @_card in ['custom', 'date-custom', 'note-custom']
         @$el.find('.appearance-card').removeClass('is-selected')
         $(evt.currentTarget).addClass('is-selected')
         @_renderSecondaryControl(questionType)
@@ -1156,7 +1177,7 @@ module.exports = do ->
           $ctrl.find('.appearance-columns-control__hint code').text(hintVal)
           @_writeModelValue()
 
-      else if @_card in ['custom', 'date-custom']
+      else if @_card in ['custom', 'date-custom', 'note-custom']
         existingText = @_customText or ''
         $input = $('<input/>', {
           type: 'text'

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -21,16 +21,16 @@ module.exports = do ->
       if cleaned is '' or cleaned is 'default'
         return { card: 'file', columnCount: null, customText: null }
       if cleaned is 'other'
-        return { card: 'file-custom', columnCount: null, customText: '' }
-      return { card: 'file-custom', columnCount: null, customText: cleaned }
+        return { card: 'custom', columnCount: null, customText: '' }
+      return { card: 'custom', columnCount: null, customText: cleaned }
 
     # Note-specific card grid
     if questionType is 'note'
       if cleaned is '' or cleaned is 'default'
         return { card: 'note', columnCount: null, customText: null }
       if cleaned is 'other'
-        return { card: 'note-custom', columnCount: null, customText: '' }
-      return { card: 'note-custom', columnCount: null, customText: cleaned }
+        return { card: 'custom', columnCount: null, customText: '' }
+      return { card: 'custom', columnCount: null, customText: cleaned }
 
     # Text-specific card grid
     if questionType is 'text'
@@ -51,8 +51,8 @@ module.exports = do ->
       if cleaned is '' or cleaned is 'default'
         return { card: 'full-date', columnCount: null, customText: null }
       if cleaned is 'other'
-        return { card: 'date-custom', columnCount: null, customText: '' }
-      return { card: 'date-custom', columnCount: null, customText: cleaned }
+        return { card: 'custom', columnCount: null, customText: '' }
+      return { card: 'custom', columnCount: null, customText: cleaned }
 
     if cleaned is 'likert'
       if questionType is 'select_one'
@@ -100,19 +100,10 @@ module.exports = do ->
       when 'single-line' then ''
       when 'paragraph'   then 'multiline'
       when 'file'        then ''
-      when 'file-custom'
-        text = ((customText or '').trim())
-        if text then text else 'other'
       when 'note'        then ''
-      when 'note-custom'
-        text = ((customText or '').trim())
-        if text then text else 'other'
       when 'full-date'   then ''
       when 'month-year'  then 'month-year'
       when 'year'        then 'year'
-      when 'date-custom'
-        text = ((customText or '').trim())
-        if text then text else 'other'
       when 'dropdown'      then 'minimal'
       when 'columns-buttons'
         if columnCount? then "columns-#{columnCount}" else 'columns'
@@ -135,16 +126,10 @@ module.exports = do ->
       when 'single-line'            then t('Single line')
       when 'paragraph'              then t('Paragraph')
       when 'file'                   then t('File upload')
-      when 'file-custom'
-        if customText then "#{t('Custom')}: #{customText}" else t('Custom')
       when 'note'                   then t('Note')
-      when 'note-custom'
-        if customText then "#{t('Custom')}: #{customText}" else t('Custom')
       when 'full-date'              then t('Full date')
       when 'month-year'             then t('Month & year')
       when 'year'                   then t('Year only')
-      when 'date-custom'
-        if customText then "#{t('Custom')}: #{customText}" else t('Custom')
       when 'dropdown'               then t('Dropdown')
       when 'image-grid'             then t('Image grid')
       when 'image-grid-labels-only' then t('Image grid (labels only)')
@@ -949,11 +934,8 @@ module.exports = do ->
     'single-line': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="11" width="46" height="12" rx="2" stroke="#444" stroke-width="1.3"/><text x="8" y="20" font-size="9" fill="#444" font-family="Arial, sans-serif" font-weight="700">abc</text><line x1="24" y1="14" x2="24" y2="21" stroke="#378ADD" stroke-width="1.2"/></svg>'
     'paragraph': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><rect x="3" y="3" width="46" height="28" rx="2" stroke="#444" stroke-width="1.3"/><line x1="7" y1="10" x2="42" y2="10" stroke="#444" stroke-width="1.1" opacity="0.5"/><line x1="7" y1="16" x2="45" y2="16" stroke="#444" stroke-width="1.1" opacity="0.5"/><line x1="7" y1="22" x2="38" y2="22" stroke="#444" stroke-width="1.1" opacity="0.5"/><path d="M44 27 L48 27 L48 31" stroke="#444" stroke-width="1.1" fill="none"/></svg>'
     'custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 34" fill="none"><path d="M12 8 Q6 8 6 14 L6 20 Q6 26 12 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M40 8 Q46 8 46 14 L46 20 Q46 26 40 26" stroke="#444" stroke-width="1.5" fill="none" stroke-linecap="round"/><text x="17" y="22" font-size="12" fill="#378ADD" font-family="Menlo, Consolas, monospace" font-weight="700">&lt;/&gt;</text></svg>'
-    'date-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'file': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><path d="M17 4 L17 40 L55 40 L55 14 L45 4 Z" stroke="#888" stroke-width="1.3"/><path d="M45 4 L45 14 L55 14" stroke="#888" stroke-width="1.1" fill="none"/><line x1="36" y1="33" x2="36" y2="22" stroke="#888" stroke-width="1.4" stroke-linecap="round"/><path d="M31 27 L36 22 L41 27" stroke="#888" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>'
-    'file-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'note': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="6" width="56" height="32" rx="3" stroke="#888" stroke-width="1.2"/><rect x="14" y="13" width="44" height="4" rx="1" fill="#888" fill-opacity="0.22"/><rect x="14" y="21" width="36" height="4" rx="1" fill="#888" fill-opacity="0.22"/><rect x="14" y="29" width="26" height="4" rx="1" fill="#888" fill-opacity="0.22"/></svg>'
-    'note-custom': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="8" y="9" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><rect x="8" y="25" width="56" height="10" rx="2" stroke="#888" stroke-width="1.1" stroke-dasharray="3 2"/><text x="36" y="16" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">appearance=</text><text x="36" y="31" font-size="5.5" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">w3 my-class</text></svg>'
     'full-date': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="2" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="11" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">DD</text><rect x="27" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="52" y="14" width="18" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="61" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
     'month-year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="10" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="20" y="23" font-size="7" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">MM</text><rect x="42" y="14" width="20" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="52" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
     'year': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 44" fill="none"><rect x="20" y="14" width="32" height="16" rx="2.5" stroke="#888" stroke-width="1.3"/><text x="36" y="23" font-size="6" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace">YYYY</text></svg>'
@@ -986,15 +968,15 @@ module.exports = do ->
       { slug: 'full-date',  label: t('Full date') }
       { slug: 'month-year', label: t('Month & year') }
       { slug: 'year',        label: t('Year only') }
-      { slug: 'date-custom', label: t('Custom') }
+      { slug: 'custom', label: t('Custom') }
     ]
     note = [
       { slug: 'note',        label: t('Note') }
-      { slug: 'note-custom', label: t('Custom') }
+      { slug: 'custom', label: t('Custom') }
     ]
     file = [
       { slug: 'file',        label: t('File upload') }
-      { slug: 'file-custom', label: t('Custom') }
+      { slug: 'custom', label: t('Custom') }
     ]
     text = [
       { slug: 'single-line', label: t('Single line') }
@@ -1151,7 +1133,7 @@ module.exports = do ->
         slug = $(el).data('card-slug')
         @_card = slug
         @_columnCount = null unless @_card in ['columns-buttons', 'columns-labels-only']
-        @_customText = null unless @_card in ['custom', 'date-custom', 'note-custom', 'file-custom']
+        @_customText = null unless @_card is 'custom'
         @$el.find('.appearance-card').removeClass('is-selected').attr('aria-pressed', 'false')
         $(el).addClass('is-selected').attr('aria-pressed', 'true')
         @_renderSecondaryControl(questionType)
@@ -1223,7 +1205,7 @@ module.exports = do ->
           $ctrl.find('.appearance-columns-control__hint code').text(hintVal)
           @_writeModelValue()
 
-      else if @_card in ['custom', 'date-custom', 'note-custom', 'file-custom']
+      else if @_card is 'custom'
         existingText = @_customText or ''
         $input = $('<input/>', {
           type: 'text'

--- a/test/xlform/questionTypeForms.tests.coffee
+++ b/test/xlform/questionTypeForms.tests.coffee
@@ -148,6 +148,11 @@ do ->
       result = ctx.html()
       expect(result).toBe('')
 
+    it 'note html() returns empty string (card grid path, no legacy textbox)', ->
+      ctx = buildAppearanceMixinCtx('note')
+      result = ctx.html()
+      expect(result).toBe('')
+
     it 'integer html() renders a dropdown with analog-scale options', ->
       ctx = buildAppearanceMixinCtx('integer')
       result = ctx.html()

--- a/test/xlform/questionTypeForms.tests.coffee
+++ b/test/xlform/questionTypeForms.tests.coffee
@@ -57,10 +57,6 @@ do ->
         types = ctx.getTypes()
         expect(types).toBeUndefined()
 
-      it 'text uses card grid path (isCardGridType is true)', ->
-        ctx = buildAppearanceMixinCtx('text')
-        expect(ctx.isCardGridType()).toBe(true)
-
     describe 'select_multiple', ->
       it 'select_multiple uses card grid path (isCardGridType is true)', ->
         ctx = buildAppearanceMixinCtx('select_multiple')

--- a/test/xlform/questionTypeForms.tests.coffee
+++ b/test/xlform/questionTypeForms.tests.coffee
@@ -102,7 +102,7 @@ do ->
         expect(types.indexOf('analog-scale vertical')).not.toBe(-1)
 
     describe 'types with no specific appearance options', ->
-      noAppTypes = ['decimal', 'note', 'file', 'audio', 'video']
+      noAppTypes = ['decimal', 'audio', 'video']
       for qtype in noAppTypes
         do (qtype) ->
           it "#{qtype} getTypes() returns undefined (textbox fallback)", ->
@@ -150,6 +150,11 @@ do ->
 
     it 'note html() returns empty string (card grid path, no legacy textbox)', ->
       ctx = buildAppearanceMixinCtx('note')
+      result = ctx.html()
+      expect(result).toBe('')
+
+    it 'file html() returns empty string (card grid path, no legacy textbox)', ->
+      ctx = buildAppearanceMixinCtx('file')
       result = ctx.html()
       expect(result).toBe('')
 

--- a/test/xlform/questionTypeForms.tests.coffee
+++ b/test/xlform/questionTypeForms.tests.coffee
@@ -38,11 +38,14 @@ do ->
   describe 'questionTypeForms: appearance.getTypes() — per question type', ->
 
     describe 'text', ->
-      it 'returns ["multiline"] for text', ->
+      it 'text uses card grid path (isCardGridType is true)', ->
+        ctx = buildAppearanceMixinCtx('text')
+        expect(ctx.isCardGridType()).toBe(true)
+
+      it 'text getTypes() returns undefined (card grid path)', ->
         ctx = buildAppearanceMixinCtx('text')
         types = ctx.getTypes()
-        expect(Array.isArray(types)).toBe(true)
-        expect(types.indexOf('multiline')).not.toBe(-1)
+        expect(types).toBeUndefined()
 
     describe 'select_one', ->
       it 'select_one uses card grid path (isCardGridType is true)', ->
@@ -54,9 +57,9 @@ do ->
         types = ctx.getTypes()
         expect(types).toBeUndefined()
 
-      it 'text does not use card grid (isCardGridType is false)', ->
+      it 'text uses card grid path (isCardGridType is true)', ->
         ctx = buildAppearanceMixinCtx('text')
-        expect(ctx.isCardGridType()).toBe(false)
+        expect(ctx.isCardGridType()).toBe(true)
 
     describe 'select_multiple', ->
       it 'select_multiple uses card grid path (isCardGridType is true)', ->
@@ -120,11 +123,10 @@ do ->
   ###############################################################
   describe 'questionTypeForms: appearance.html() — uses dropdown where options exist', ->
 
-    it 'text html() renders a dropdown with at least "select" + "multiline"', ->
+    it 'text html() returns empty string (card grid path, no legacy dropdown)', ->
       ctx = buildAppearanceMixinCtx('text')
       result = ctx.html()
-      expect(result.indexOf('<select')).not.toBe(-1)
-      expect(result.indexOf('multiline')).not.toBe(-1)
+      expect(result).toBe('')
 
     it 'select_one html() returns empty string (card grid rendered in afterRender)', ->
       ctx = buildAppearanceMixinCtx('select_one')

--- a/test/xlform/questionTypeForms.tests.coffee
+++ b/test/xlform/questionTypeForms.tests.coffee
@@ -143,11 +143,10 @@ do ->
       expect(result.indexOf('draw')).not.toBe(-1)
       expect(result.indexOf('signature')).not.toBe(-1)
 
-    it 'date html() renders a dropdown with month-year, year', ->
+    it 'date html() returns empty string (card grid path, no legacy dropdown)', ->
       ctx = buildAppearanceMixinCtx('date')
       result = ctx.html()
-      expect(result.indexOf('<select')).not.toBe(-1)
-      expect(result.indexOf('month-year')).not.toBe(-1)
+      expect(result).toBe('')
 
     it 'integer html() renders a dropdown with analog-scale options', ->
       ctx = buildAppearanceMixinCtx('integer')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -603,3 +603,60 @@ do ->
 
     it 'date-custom with null text → "other"', ->
       expect(buildModelValue('date-custom', null, null)).toBe('other')
+
+  ###############################################################
+  # appearance picker: parseAppearanceValue — note type
+  ###############################################################
+  describe 'parseAppearanceValue (note)', ->
+    {parseAppearanceValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'empty string → note card for note', ->
+      expect(parseAppearanceValue('', 'note')).toEqual { card: 'note', columnCount: null, customText: null }
+
+    it 'null → note card for note', ->
+      expect(parseAppearanceValue(null, 'note')).toEqual { card: 'note', columnCount: null, customText: null }
+
+    it '"default" → note card for note', ->
+      expect(parseAppearanceValue('default', 'note')).toEqual { card: 'note', columnCount: null, customText: null }
+
+    it '"other" → note-custom with empty text for note', ->
+      expect(parseAppearanceValue('other', 'note')).toEqual { card: 'note-custom', columnCount: null, customText: '' }
+
+    it 'unknown value → note-custom with raw text for note', ->
+      expect(parseAppearanceValue('compact', 'note')).toEqual { card: 'note-custom', columnCount: null, customText: 'compact' }
+
+    it 'width token stripped before note parse', ->
+      expect(parseAppearanceValue('w3', 'note')).toEqual { card: 'note', columnCount: null, customText: null }
+
+  ###############################################################
+  # appearance picker: buildModelValue — note cards
+  ###############################################################
+  describe 'buildModelValue (note cards)', ->
+    {buildModelValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'note → empty string', ->
+      expect(buildModelValue('note', null, null)).toBe('')
+
+    it 'note-custom with text → raw text', ->
+      expect(buildModelValue('note-custom', null, 'compact')).toBe('compact')
+
+    it 'note-custom with empty text → "other"', ->
+      expect(buildModelValue('note-custom', null, '')).toBe('other')
+
+    it 'note-custom with null text → "other"', ->
+      expect(buildModelValue('note-custom', null, null)).toBe('other')
+
+  ###############################################################
+  # appearance picker: buildPillText — note cards
+  ###############################################################
+  describe 'buildPillText (note cards)', ->
+    {buildPillText} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'note → "Note"', ->
+      expect(buildPillText('note', null, null)).toBe('Note')
+
+    it 'note-custom with text → "Custom: compact"', ->
+      expect(buildPillText('note-custom', null, 'compact')).toBe('Custom: compact')
+
+    it 'note-custom with no text → "Custom"', ->
+      expect(buildPillText('note-custom', null, null)).toBe('Custom')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -604,6 +604,7 @@ do ->
     it 'date-custom with null text → "other"', ->
       expect(buildModelValue('date-custom', null, null)).toBe('other')
 
+
   ###############################################################
   # appearance picker: parseAppearanceValue — note type
   ###############################################################

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -580,6 +580,9 @@ do ->
     it 'width-only → full-date for date', ->
       expect(parseAppearanceValue('w3', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
 
+    it '"default" → full-date for date (legacy value treated as default)', ->
+      expect(parseAppearanceValue('default', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
+
   ###############################################################
   # appearance picker: buildModelValue — date cards
   ###############################################################

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -661,3 +661,45 @@ do ->
 
     it 'note-custom with no text → "Custom"', ->
       expect(buildPillText('note-custom', null, null)).toBe('Custom')
+
+  describe 'parseAppearanceValue (file)', ->
+    {parseAppearanceValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'empty string → file card (default)', ->
+      expect(parseAppearanceValue('', 'file')).toEqual { card: 'file', columnCount: null, customText: null }
+
+    it '"default" → file card', ->
+      expect(parseAppearanceValue('default', 'file')).toEqual { card: 'file', columnCount: null, customText: null }
+
+    it '"other" → file-custom with empty text', ->
+      expect(parseAppearanceValue('other', 'file')).toEqual { card: 'file-custom', columnCount: null, customText: '' }
+
+    it 'unknown value → file-custom with raw text', ->
+      expect(parseAppearanceValue('compact', 'file')).toEqual { card: 'file-custom', columnCount: null, customText: 'compact' }
+
+  describe 'buildModelValue (file cards)', ->
+    {buildModelValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'file → empty string', ->
+      expect(buildModelValue('file', null, null)).toBe('')
+
+    it 'file-custom with text → raw text', ->
+      expect(buildModelValue('file-custom', null, 'compact')).toBe('compact')
+
+    it 'file-custom with empty text → "other"', ->
+      expect(buildModelValue('file-custom', null, '')).toBe('other')
+
+    it 'file-custom with null text → "other"', ->
+      expect(buildModelValue('file-custom', null, null)).toBe('other')
+
+  describe 'buildPillText (file cards)', ->
+    {buildPillText} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'file → "File upload"', ->
+      expect(buildPillText('file', null, null)).toBe('File upload')
+
+    it 'file-custom with text → "Custom: compact"', ->
+      expect(buildPillText('file-custom', null, 'compact')).toBe('Custom: compact')
+
+    it 'file-custom with no text → "Custom"', ->
+      expect(buildPillText('file-custom', null, null)).toBe('Custom')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -706,3 +706,69 @@ do ->
 
     it 'file-custom with no text → "Custom"', ->
       expect(buildPillText('file-custom', null, null)).toBe('Custom')
+
+  # appearance picker: parseAppearanceValue — text type
+  ##############################################################################
+
+  describe 'parseAppearanceValue (text)', ->
+    {parseAppearanceValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'empty string → single-line', ->
+      expect(parseAppearanceValue('', 'text')).toEqual { card: 'single-line', columnCount: null, customText: null }
+
+    it 'null → single-line', ->
+      expect(parseAppearanceValue(null, 'text')).toEqual { card: 'single-line', columnCount: null, customText: null }
+
+    it '"default" → single-line', ->
+      expect(parseAppearanceValue('default', 'text')).toEqual { card: 'single-line', columnCount: null, customText: null }
+
+    it '"multiline" → paragraph', ->
+      expect(parseAppearanceValue('multiline', 'text')).toEqual { card: 'paragraph', columnCount: null, customText: null }
+
+    it '"other" → custom with empty text', ->
+      expect(parseAppearanceValue('other', 'text')).toEqual { card: 'custom', columnCount: null, customText: '' }
+
+    it 'unknown value → custom with raw text', ->
+      expect(parseAppearanceValue('compact', 'text')).toEqual { card: 'custom', columnCount: null, customText: 'compact' }
+
+    it 'w-prefix stripped and maps to single-line', ->
+      expect(parseAppearanceValue('w3', 'text')).toEqual { card: 'single-line', columnCount: null, customText: null }
+
+  # appearance picker: buildModelValue — text cards
+  ##############################################################################
+
+  describe 'buildModelValue (text cards)', ->
+    {buildModelValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'single-line → empty string', ->
+      expect(buildModelValue('single-line', null, null)).toBe('')
+
+    it 'paragraph → "multiline"', ->
+      expect(buildModelValue('paragraph', null, null)).toBe('multiline')
+
+    it 'custom (text) with text → raw text', ->
+      expect(buildModelValue('custom', null, 'compact')).toBe('compact')
+
+    it 'custom (text) with empty text → "other"', ->
+      expect(buildModelValue('custom', null, '')).toBe('other')
+
+    it 'custom (text) with null text → "other"', ->
+      expect(buildModelValue('custom', null, null)).toBe('other')
+
+  # appearance picker: buildPillText — text cards
+  ##############################################################################
+
+  describe 'buildPillText (text cards)', ->
+    {buildPillText} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'single-line → "Single line"', ->
+      expect(buildPillText('single-line', null, null)).toBe('Single line')
+
+    it 'paragraph → "Paragraph"', ->
+      expect(buildPillText('paragraph', null, null)).toBe('Paragraph')
+
+    it 'custom (text) with text → "Custom: compact"', ->
+      expect(buildPillText('custom', null, 'compact')).toBe('Custom: compact')
+
+    it 'custom (text) with no text → "Custom"', ->
+      expect(buildPillText('custom', null, null)).toBe('Custom')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -541,6 +541,12 @@ do ->
     it 'year → "Year only"', ->
       expect(buildPillText('year', null, null)).toBe('Year only')
 
+    it 'date-custom with text → "Custom: compact"', ->
+      expect(buildPillText('date-custom', null, 'compact')).toBe('Custom: compact')
+
+    it 'date-custom with no text → "Custom"', ->
+      expect(buildPillText('date-custom', null, null)).toBe('Custom')
+
   ###############################################################
   # appearance picker: parseAppearanceValue — date type
   ###############################################################
@@ -559,11 +565,14 @@ do ->
     it 'year → year card for date', ->
       expect(parseAppearanceValue('year', 'date')).toEqual { card: 'year', columnCount: null, customText: null }
 
-    it 'unknown value → custom for date', ->
-      expect(parseAppearanceValue('compact', 'date')).toEqual { card: 'custom', columnCount: null, customText: 'compact' }
+    it 'unknown value → date-custom for date', ->
+      expect(parseAppearanceValue('compact', 'date')).toEqual { card: 'date-custom', columnCount: null, customText: 'compact' }
 
-    it '"other" → custom with empty text for date', ->
-      expect(parseAppearanceValue('other', 'date')).toEqual { card: 'custom', columnCount: null, customText: '' }
+    it '"other" → date-custom with empty text for date', ->
+      expect(parseAppearanceValue('other', 'date')).toEqual { card: 'date-custom', columnCount: null, customText: '' }
+
+    it '"default" → full-date for date (legacy value treated as default)', ->
+      expect(parseAppearanceValue('default', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
 
     it 'width token stripped before date parse', ->
       expect(parseAppearanceValue('month-year w3', 'date')).toEqual { card: 'month-year', columnCount: null, customText: null }
@@ -585,3 +594,12 @@ do ->
 
     it 'year → "year"', ->
       expect(buildModelValue('year', null, null)).toBe('year')
+
+    it 'date-custom with text → raw text', ->
+      expect(buildModelValue('date-custom', null, 'compact')).toBe('compact')
+
+    it 'date-custom with empty text → "other"', ->
+      expect(buildModelValue('date-custom', null, '')).toBe('other')
+
+    it 'date-custom with null text → "other"', ->
+      expect(buildModelValue('date-custom', null, null)).toBe('other')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -580,9 +580,6 @@ do ->
     it 'width-only → full-date for date', ->
       expect(parseAppearanceValue('w3', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
 
-    it '"default" → full-date for date (legacy value treated as default)', ->
-      expect(parseAppearanceValue('default', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
-
   ###############################################################
   # appearance picker: buildModelValue — date cards
   ###############################################################

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -531,3 +531,57 @@ do ->
 
     it 'custom with no text → "Custom"', ->
       expect(buildPillText('custom', null, null)).toBe('Custom')
+
+    it 'full-date → "Full date"', ->
+      expect(buildPillText('full-date', null, null)).toBe('Full date')
+
+    it 'month-year → "Month & year"', ->
+      expect(buildPillText('month-year', null, null)).toBe('Month & year')
+
+    it 'year → "Year only"', ->
+      expect(buildPillText('year', null, null)).toBe('Year only')
+
+  ###############################################################
+  # appearance picker: parseAppearanceValue — date type
+  ###############################################################
+  describe 'parseAppearanceValue (date)', ->
+    {parseAppearanceValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'empty string → full-date for date', ->
+      expect(parseAppearanceValue('', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
+
+    it 'null → full-date for date', ->
+      expect(parseAppearanceValue(null, 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
+
+    it 'month-year → month-year card for date', ->
+      expect(parseAppearanceValue('month-year', 'date')).toEqual { card: 'month-year', columnCount: null, customText: null }
+
+    it 'year → year card for date', ->
+      expect(parseAppearanceValue('year', 'date')).toEqual { card: 'year', columnCount: null, customText: null }
+
+    it 'unknown value → custom for date', ->
+      expect(parseAppearanceValue('compact', 'date')).toEqual { card: 'custom', columnCount: null, customText: 'compact' }
+
+    it '"other" → custom with empty text for date', ->
+      expect(parseAppearanceValue('other', 'date')).toEqual { card: 'custom', columnCount: null, customText: '' }
+
+    it 'width token stripped before date parse', ->
+      expect(parseAppearanceValue('month-year w3', 'date')).toEqual { card: 'month-year', columnCount: null, customText: null }
+
+    it 'width-only → full-date for date', ->
+      expect(parseAppearanceValue('w3', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
+
+  ###############################################################
+  # appearance picker: buildModelValue — date cards
+  ###############################################################
+  describe 'buildModelValue (date cards)', ->
+    {buildModelValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'full-date → empty string', ->
+      expect(buildModelValue('full-date', null, null)).toBe('')
+
+    it 'month-year → "month-year"', ->
+      expect(buildModelValue('month-year', null, null)).toBe('month-year')
+
+    it 'year → "year"', ->
+      expect(buildModelValue('year', null, null)).toBe('year')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -541,11 +541,11 @@ do ->
     it 'year → "Year only"', ->
       expect(buildPillText('year', null, null)).toBe('Year only')
 
-    it 'date-custom with text → "Custom: compact"', ->
-      expect(buildPillText('date-custom', null, 'compact')).toBe('Custom: compact')
+    it 'custom with text → "Custom: compact"', ->
+      expect(buildPillText('custom', null, 'compact')).toBe('Custom: compact')
 
-    it 'date-custom with no text → "Custom"', ->
-      expect(buildPillText('date-custom', null, null)).toBe('Custom')
+    it 'custom with no text → "Custom"', ->
+      expect(buildPillText('custom', null, null)).toBe('Custom')
 
   ###############################################################
   # appearance picker: parseAppearanceValue — date type
@@ -565,11 +565,11 @@ do ->
     it 'year → year card for date', ->
       expect(parseAppearanceValue('year', 'date')).toEqual { card: 'year', columnCount: null, customText: null }
 
-    it 'unknown value → date-custom for date', ->
-      expect(parseAppearanceValue('compact', 'date')).toEqual { card: 'date-custom', columnCount: null, customText: 'compact' }
+    it 'unknown value → custom for date', ->
+      expect(parseAppearanceValue('compact', 'date')).toEqual { card: 'custom', columnCount: null, customText: 'compact' }
 
-    it '"other" → date-custom with empty text for date', ->
-      expect(parseAppearanceValue('other', 'date')).toEqual { card: 'date-custom', columnCount: null, customText: '' }
+    it '"other" → custom with empty text for date', ->
+      expect(parseAppearanceValue('other', 'date')).toEqual { card: 'custom', columnCount: null, customText: '' }
 
     it '"default" → full-date for date (legacy value treated as default)', ->
       expect(parseAppearanceValue('default', 'date')).toEqual { card: 'full-date', columnCount: null, customText: null }
@@ -595,14 +595,14 @@ do ->
     it 'year → "year"', ->
       expect(buildModelValue('year', null, null)).toBe('year')
 
-    it 'date-custom with text → raw text', ->
-      expect(buildModelValue('date-custom', null, 'compact')).toBe('compact')
+    it 'custom with text → raw text', ->
+      expect(buildModelValue('custom', null, 'compact')).toBe('compact')
 
-    it 'date-custom with empty text → "other"', ->
-      expect(buildModelValue('date-custom', null, '')).toBe('other')
+    it 'custom with empty text → "other"', ->
+      expect(buildModelValue('custom', null, '')).toBe('other')
 
-    it 'date-custom with null text → "other"', ->
-      expect(buildModelValue('date-custom', null, null)).toBe('other')
+    it 'custom with null text → "other"', ->
+      expect(buildModelValue('custom', null, null)).toBe('other')
 
 
   ###############################################################
@@ -620,11 +620,11 @@ do ->
     it '"default" → note card for note', ->
       expect(parseAppearanceValue('default', 'note')).toEqual { card: 'note', columnCount: null, customText: null }
 
-    it '"other" → note-custom with empty text for note', ->
-      expect(parseAppearanceValue('other', 'note')).toEqual { card: 'note-custom', columnCount: null, customText: '' }
+    it '"other" → custom with empty text for note', ->
+      expect(parseAppearanceValue('other', 'note')).toEqual { card: 'custom', columnCount: null, customText: '' }
 
-    it 'unknown value → note-custom with raw text for note', ->
-      expect(parseAppearanceValue('compact', 'note')).toEqual { card: 'note-custom', columnCount: null, customText: 'compact' }
+    it 'unknown value → custom with raw text for note', ->
+      expect(parseAppearanceValue('compact', 'note')).toEqual { card: 'custom', columnCount: null, customText: 'compact' }
 
     it 'width token stripped before note parse', ->
       expect(parseAppearanceValue('w3', 'note')).toEqual { card: 'note', columnCount: null, customText: null }
@@ -638,14 +638,14 @@ do ->
     it 'note → empty string', ->
       expect(buildModelValue('note', null, null)).toBe('')
 
-    it 'note-custom with text → raw text', ->
-      expect(buildModelValue('note-custom', null, 'compact')).toBe('compact')
+    it 'custom with text → raw text', ->
+      expect(buildModelValue('custom', null, 'compact')).toBe('compact')
 
-    it 'note-custom with empty text → "other"', ->
-      expect(buildModelValue('note-custom', null, '')).toBe('other')
+    it 'custom with empty text → "other"', ->
+      expect(buildModelValue('custom', null, '')).toBe('other')
 
-    it 'note-custom with null text → "other"', ->
-      expect(buildModelValue('note-custom', null, null)).toBe('other')
+    it 'custom with null text → "other"', ->
+      expect(buildModelValue('custom', null, null)).toBe('other')
 
   ###############################################################
   # appearance picker: buildPillText — note cards
@@ -656,11 +656,11 @@ do ->
     it 'note → "Note"', ->
       expect(buildPillText('note', null, null)).toBe('Note')
 
-    it 'note-custom with text → "Custom: compact"', ->
-      expect(buildPillText('note-custom', null, 'compact')).toBe('Custom: compact')
+    it 'custom with text → "Custom: compact"', ->
+      expect(buildPillText('custom', null, 'compact')).toBe('Custom: compact')
 
-    it 'note-custom with no text → "Custom"', ->
-      expect(buildPillText('note-custom', null, null)).toBe('Custom')
+    it 'custom with no text → "Custom"', ->
+      expect(buildPillText('custom', null, null)).toBe('Custom')
 
   describe 'parseAppearanceValue (file)', ->
     {parseAppearanceValue} = require('../../jsapp/xlform/src/view.rowDetail')
@@ -671,11 +671,11 @@ do ->
     it '"default" → file card', ->
       expect(parseAppearanceValue('default', 'file')).toEqual { card: 'file', columnCount: null, customText: null }
 
-    it '"other" → file-custom with empty text', ->
-      expect(parseAppearanceValue('other', 'file')).toEqual { card: 'file-custom', columnCount: null, customText: '' }
+    it '"other" → custom with empty text', ->
+      expect(parseAppearanceValue('other', 'file')).toEqual { card: 'custom', columnCount: null, customText: '' }
 
-    it 'unknown value → file-custom with raw text', ->
-      expect(parseAppearanceValue('compact', 'file')).toEqual { card: 'file-custom', columnCount: null, customText: 'compact' }
+    it 'unknown value → custom with raw text', ->
+      expect(parseAppearanceValue('compact', 'file')).toEqual { card: 'custom', columnCount: null, customText: 'compact' }
 
   describe 'buildModelValue (file cards)', ->
     {buildModelValue} = require('../../jsapp/xlform/src/view.rowDetail')
@@ -683,14 +683,14 @@ do ->
     it 'file → empty string', ->
       expect(buildModelValue('file', null, null)).toBe('')
 
-    it 'file-custom with text → raw text', ->
-      expect(buildModelValue('file-custom', null, 'compact')).toBe('compact')
+    it 'custom with text → raw text', ->
+      expect(buildModelValue('custom', null, 'compact')).toBe('compact')
 
-    it 'file-custom with empty text → "other"', ->
-      expect(buildModelValue('file-custom', null, '')).toBe('other')
+    it 'custom with empty text → "other"', ->
+      expect(buildModelValue('custom', null, '')).toBe('other')
 
-    it 'file-custom with null text → "other"', ->
-      expect(buildModelValue('file-custom', null, null)).toBe('other')
+    it 'custom with null text → "other"', ->
+      expect(buildModelValue('custom', null, null)).toBe('other')
 
   describe 'buildPillText (file cards)', ->
     {buildPillText} = require('../../jsapp/xlform/src/view.rowDetail')
@@ -698,11 +698,11 @@ do ->
     it 'file → "File upload"', ->
       expect(buildPillText('file', null, null)).toBe('File upload')
 
-    it 'file-custom with text → "Custom: compact"', ->
-      expect(buildPillText('file-custom', null, 'compact')).toBe('Custom: compact')
+    it 'custom with text → "Custom: compact"', ->
+      expect(buildPillText('custom', null, 'compact')).toBe('Custom: compact')
 
-    it 'file-custom with no text → "Custom"', ->
-      expect(buildPillText('file-custom', null, null)).toBe('Custom')
+    it 'custom with no text → "Custom"', ->
+      expect(buildPillText('custom', null, null)).toBe('Custom')
 
   # appearance picker: parseAppearanceValue — text type
   ##############################################################################


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Replaces the legacy Appearance dropdown for Text items with a collapsible card-grid picker that provides three options:

Single Line(default)
Paragraph
Custom
Each option is displayed as a card with an SVG icon and is mapped to its corresponding XForm appearance value.

https://jira.openclinica.com/browse/OC-27710
https://github.com/kobotoolbox/docs/issues/559

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
