### PR TITLE
OC-28006 Replace the Width dropdown with an adaptive Item Width control

### DIFF
--- a/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
@@ -248,6 +248,12 @@
       transform: rotate(180deg);
     }
   }
+
+  &:focus-visible {
+    outline: 2px solid #378ADD;
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
 }
 
 .item-width__title {
@@ -351,6 +357,11 @@
 
   &:hover {
     border-color: #94A3B8;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #378ADD;
+    outline-offset: 2px;
   }
 
   &.is-selected {

--- a/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
@@ -218,3 +218,205 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+// ==========================================================================
+// Item width sub-section (inside Advanced options)
+// ==========================================================================
+
+.item-width-subsection {
+  padding: 6px 0 4px;
+  border-bottom: 1px solid #CBD5E1;
+  margin-bottom: 4px;
+}
+
+.item-width__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #334155;
+  padding: 2px 0;
+  cursor: pointer;
+  user-select: none;
+  border: none;
+  background: none;
+  width: 100%;
+
+  &[aria-expanded="true"] {
+    .item-width__chev {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+.item-width__title {
+  text-align: left;
+  color: #334155;
+}
+
+.item-width__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #edf4fc;
+  border: 0.5px solid #378ADD;
+  border-radius: 10px;
+  padding: 2px 9px;
+  font-size: 11px;
+  color: #185FA5;
+  font-weight: 600;
+  margin-left: 6px;
+
+  .pill-bar {
+    width: 30px;
+    height: 7px;
+    background: #cfe0f2;
+    border-radius: 2px;
+    overflow: hidden;
+    display: inline-block;
+    flex-shrink: 0;
+
+    .pill-fill {
+      height: 100%;
+      background: #378ADD;
+      border-radius: 2px;
+      display: block;
+    }
+  }
+}
+
+.item-width__chev {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 35px;
+  height: 35px;
+  font-size: 14px;
+  color: #475569;
+  align-self: center;
+  flex-shrink: 0;
+  margin-left: auto;
+  transition: transform 0.2s ease;
+}
+
+.item-width__context {
+  font-size: 11px;
+  color: #64748B;
+  font-style: italic;
+  margin: 3px 0 0 0;
+}
+
+.item-width__body {
+  margin-top: 8px;
+}
+
+.item-width__span-note {
+  font-size: 11px;
+  color: #185FA5;
+  background: #edf4fc;
+  border: 0.5px solid #cfe0f2;
+  border-radius: 3px;
+  padding: 4px 8px;
+  margin-bottom: 10px;
+}
+
+.item-width__advisory {
+  font-size: 11px;
+  color: #94A3B8;
+  font-style: italic;
+  margin-top: 6px;
+}
+
+// Item width card grid
+
+.item-width__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  padding-bottom: 4px;
+}
+
+.width-card {
+  background: #fff;
+  border: 0.5px solid #CBD5E1;
+  border-radius: 5px;
+  padding: 10px 6px 7px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    border-color: #94A3B8;
+  }
+
+  &.is-selected {
+    border: 1.5px solid #378ADD;
+    background: #edf4fc;
+
+    .width-card__label {
+      color: #185FA5;
+    }
+
+    .bar-fill {
+      opacity: 1;
+    }
+
+    .seg span.on {
+      opacity: 1;
+    }
+  }
+}
+
+// Proportional fill bar (G=4 fraction mode)
+.width-card .bar-wrap {
+  width: 100%;
+  height: 8px;
+  background: #e8edf2;
+  border-radius: 3px;
+  overflow: hidden;
+
+  .bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: #378ADD;
+    opacity: 0.7;
+  }
+}
+
+// Segment-tick bar (G≠4 span mode)
+.width-card .seg {
+  width: 100%;
+  height: 8px;
+  display: flex;
+  gap: 1px;
+
+  span {
+    flex: 1;
+    background: #e8edf2;
+    border-radius: 1px;
+
+    &.on {
+      background: #378ADD;
+      opacity: 0.65;
+    }
+  }
+}
+
+.width-card__label {
+  font-size: 11px;
+  font-weight: 700;
+  color: #444;
+  text-align: center;
+  line-height: 1.2;
+}
+
+.width-card__code {
+  font-size: 9px;
+  color: #aaa;
+  font-family: monospace;
+  text-align: center;
+}

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
@@ -341,9 +341,10 @@
   row-gap: 12px;
   align-items: start;
 
-  .xlf-dv-default       { grid-column: 1; grid-row: 1; }
-  .xlf-dv-readonly      { grid-column: 1; grid-row: 2; }
-  .xlf-dv-oc_item_group { grid-column: 2; grid-row: 2; }
+  .item-width-subsection { grid-column: 1 / -1; }
+  .xlf-dv-default       { grid-column: 1; }
+  .xlf-dv-readonly      { grid-column: 1; }
+  .xlf-dv-oc_item_group { grid-column: 2; }
 }
 
 .card__settings__row-options {

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -913,7 +913,7 @@ module.exports = do ->
     return null unless modelValue?
     found = null
     for w in WIDTH_OPTIONS
-      found = w if modelValue.indexOf(w) isnt -1
+      found = w if new RegExp("\\b#{w}\\b").test(modelValue)
     found
 
   getParentGroupCols = (mixin) ->
@@ -923,9 +923,9 @@ module.exports = do ->
     return 4 unless appearanceDetail?
     appearance = (appearanceDetail.getValue() or '').trim()
     return 4 unless appearance
-    m = appearance.match(/\bw(\d+)\b/)
-    return 4 unless m
-    n = parseInt(m[1], 10)
+    w = getWidthFromModelValue(appearance)
+    return 4 unless w?
+    n = parseInt(w.slice(1), 10)
     if 1 <= n <= 10 then n else 4
 
   getParentGroupName = (mixin) ->
@@ -1428,7 +1428,10 @@ module.exports = do ->
       $grid.off('click.oc-width').on 'click.oc-width', '.width-card', (evt) =>
         selectWidth(evt.currentTarget)
       $grid.off('keydown.oc-width').on 'keydown.oc-width', '.width-card', (evt) =>
-        selectWidth(evt.currentTarget) if evt.key in ['Enter', ' ']
+        if evt.key in ['Enter', ' ']
+          evt.preventDefault()
+          evt.stopPropagation()
+          selectWidth(evt.currentTarget)
 
       # Collapse toggle
       $header.off('click.widthToggle').on 'click.widthToggle', (evt) =>
@@ -1444,7 +1447,10 @@ module.exports = do ->
           @_refreshWidthPill($pill)
           $pill.show()
       $header.off('keydown.widthToggle').on 'keydown.widthToggle', (evt) =>
-        $header.trigger('click') if evt.key in ['Enter', ' ']
+        if evt.key in ['Enter', ' ']
+          evt.preventDefault()
+          evt.stopPropagation()
+          $header.trigger('click')
 
     _writeWidthValue: (widthSlug) ->
       currentVal = @model.get('value') or ''

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1152,18 +1152,6 @@ module.exports = do ->
       # Render secondary control for initial state
       @_renderSecondaryControl(questionType)
 
-      # Width select (theme-grid form style only)
-      if @is_form_style_theme_grid()
-        $width_field = $("""<div class="card__settings__fields__field xlf-dv-width-row">
-          <label for="select-width">#{t('Width')}:</label>
-          <span class="settings__input"></span>
-        </div>""")
-        $width_field.find('.settings__input').append(@$select_width)
-        @$el.append($width_field)
-        width_val = @get_width_from_model_value()
-        @$select_width.val(width_val) if width_val?
-        @$select_width.on 'change', => @_writeModelValue()
-
       # Card click
       @$el.on 'click', '.appearance-card', (evt) =>
         slug = $(evt.currentTarget).data('card-slug')

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -907,6 +907,47 @@ module.exports = do ->
     ]
     if questionType is 'select_multiple' then select_multiple else select_one
 
+  WIDTH_OPTIONS = ("w#{n}" for n in [1..10])
+
+  getWidthFromModelValue = (modelValue) ->
+    return null unless modelValue?
+    found = null
+    for w in WIDTH_OPTIONS
+      found = w if modelValue.indexOf(w) isnt -1
+    found
+
+  getParentGroupCols = (mixin) ->
+    parent_group = mixin.model_get_parent_group()
+    return 4 unless parent_group?
+    appearanceDetail = parent_group.get('appearance')
+    return 4 unless appearanceDetail?
+    appearance = (appearanceDetail.getValue() or '').trim()
+    return 4 unless appearance
+    m = appearance.match(/\bw(\d+)\b/)
+    return 4 unless m
+    n = parseInt(m[1], 10)
+    if 1 <= n <= 10 then n else 4
+
+  getParentGroupName = (mixin) ->
+    parent_group = mixin.model_get_parent_group()
+    return null unless parent_group?
+    itemgroupDetail = parent_group.get('bind::oc:itemgroup')
+    nameDetail = parent_group.get('name')
+    (itemgroupDetail?.getValue() or nameDetail?.getValue() or null)
+
+  buildWidthPillText = (widthVal, groupCols) ->
+    return t('Full width') unless widthVal?
+    k = parseInt(widthVal.slice(1), 10)
+    if groupCols is 4
+      switch k
+        when 4 then t('Full width')
+        when 3 then t('3/4 width')
+        when 2 then t('Half width')
+        when 1 then t('1/4 width')
+        else "w#{k}"
+    else
+      "#{k} of #{groupCols}"
+
   viewRowDetail.DetailViewMixins.appearance =
     isCardGridType: ->
       @model_type() in ['select_one', 'select_multiple']
@@ -991,12 +1032,7 @@ module.exports = do ->
       @is_form_style('theme-grid')
 
     get_width_from_model_value: ->
-      modelValue = @model.get 'value'
-      return null unless modelValue?
-      model_width = null
-      for width_option in @width_options
-        model_width = width_option if ((modelValue.indexOf width_option) > -1)
-      model_width
+      getWidthFromModelValue(@model.get('value'))
 
     afterRender: ->
       if @isCardGridType()
@@ -1038,18 +1074,6 @@ module.exports = do ->
       # Render secondary control for initial state
       @_renderSecondaryControl(questionType)
 
-      # Width select (theme-grid form style only)
-      if @is_form_style_theme_grid()
-        $width_field = $("""<div class="card__settings__fields__field xlf-dv-width-row">
-          <label for="select-width">#{t('Width')}:</label>
-          <span class="settings__input"></span>
-        </div>""")
-        $width_field.find('.settings__input').append(@$select_width)
-        @$el.append($width_field)
-        width_val = @get_width_from_model_value()
-        @$select_width.val(width_val) if width_val?
-        @$select_width.on 'change', => @_writeModelValue()
-
       # Card click
       @$el.on 'click', '.appearance-card', (evt) =>
         slug = $(evt.currentTarget).data('card-slug')
@@ -1060,6 +1084,9 @@ module.exports = do ->
         $(evt.currentTarget).addClass('is-selected')
         @_renderSecondaryControl(questionType)
         @_writeModelValue()
+
+      # Item width section
+      @_afterRenderWidth()
 
       # Initial pill (section starts collapsed)
       @_refreshPill($pill)
@@ -1140,9 +1167,9 @@ module.exports = do ->
     _writeModelValue: ->
       value = buildModelValue(@_card, @_columnCount, @_customText)
       if @is_form_style_theme_grid()
-        width_val = @$select_width.val()
-        if width_val and width_val isnt 'select'
-          value = if value then "#{value} #{width_val}" else width_val
+        existingWidth = getWidthFromModelValue(@model.get('value') or '')
+        if existingWidth
+          value = if value then "#{value} #{existingWidth}" else existingWidth
       @model.set 'value', value
 
     _refreshPill: ($pill) ->
@@ -1214,35 +1241,8 @@ module.exports = do ->
           @group_inputs_change_handler()
 
       else
-        if @is_form_style_theme_grid()
-          $width_field = $("""<div class="card__settings__fields__field xlf-dv-width-row">
-            <label for="select-width">#{t('Width')}:</label>
-            <span class="settings__input"></span>
-          </div>""")
-          $width_field.find('.settings__input').append(@$select_width)
-          @$el.append($width_field)
-
-          parent_column = 4
-          if @model_get_parent_group()? and @model_get_parent_group_appearance() != ''
-            parent_group_appearance = @model_get_parent_group_appearance()
-            if parent_group_appearance.indexOf(' ') == -1
-              if parent_group_appearance in @width_options
-                parent_column = parent_group_appearance.slice(1)
-            else
-              parent_group_appearance_last_value = parent_group_appearance.slice(parent_group_appearance.lastIndexOf(' ') + 1)
-              if parent_group_appearance_last_value in @width_options
-                parent_column = parent_group_appearance_last_value.slice(1)
-
-          parent_column = parseInt parent_column, 10
-          text_parent_columns = "Parent group has #{parent_column} columns"
-          if parent_column == 1
-            text_parent_columns = text_parent_columns.replace('columns', 'column')
-          $help_field = $("""<div class="card__settings__fields__field card__settings__fields__field--help-text-row">
-            <label></label>
-            <span class="settings__input"></span>
-          </div>""")
-          $help_field.find('.settings__input').text(text_parent_columns)
-          @$el.append($help_field)
+        # Item width section (replaces legacy width dropdown + parent-group hint)
+        @_afterRenderWidth()
 
         $select = @$('select').not('#select-width')
         if $select.length > 0
@@ -1276,8 +1276,6 @@ module.exports = do ->
 
             if select_value?
               $select.val(select_value)
-            if select_width_value?
-              @$select_width.val(select_width_value)
             if other_value?
               $select.val('other')
               @$textbox_other.insertAfter $select
@@ -1286,9 +1284,6 @@ module.exports = do ->
               @add_input_text_change_handler(@$textbox_other, @not_group_inputs_change_handler)
 
           updateSelectPlaceholderClass()
-
-          @$select_width.on 'change', () =>
-            @not_group_inputs_change_handler()
 
           $select.on 'change', () =>
             updateSelectPlaceholderClass()
@@ -1306,27 +1301,168 @@ module.exports = do ->
           $input = @$('input')
           if modelValue? and modelValue != ''
             modelValue = modelValue.trim()
-            input_value = null
-            select_width_value = null
-
             width_model_value = @get_width_from_model_value()
             if width_model_value?
-              select_width_value = width_model_value
-              modelValue = modelValue.split(select_width_value).join('')
-
-            modelValue = modelValue.trim()
+              modelValue = modelValue.split(width_model_value).join('').trim()
             if modelValue != ''
-              input_value = modelValue
-
-            if input_value?
-              $input.val(input_value)
-            if select_width_value?
-              @$select_width.val(select_width_value)
+              $input.val(modelValue)
 
           @add_input_text_change_handler($input, @group_inputs_change_handler)
 
-          @$select_width.on 'change', () =>
-            @group_inputs_change_handler()
+    # -------------------------------------------------------------------------
+    # Item width section (new adaptive picker, replaces legacy Width dropdown)
+    # -------------------------------------------------------------------------
+
+    _afterRenderWidth: ->
+      return unless @is_form_style_theme_grid()
+      $advBody = @rowView.cardSettingsWrap.find('#js-card-settings-row-options-advanced').eq(0)
+      return unless $advBody.length
+
+      # Idempotent: remove stale sub-section from a prior render
+      $advBody.find('.js-item-width-wrap').remove()
+
+      groupCols = getParentGroupCols(@)
+      groupName = getParentGroupName(@)
+      modelValue = @model.get('value') or ''
+      currentW  = getWidthFromModelValue(modelValue)
+
+      # Context line text
+      if groupName?
+        col_word = if groupCols is 1 then t('column') else t('columns')
+        contextText = "#{t('Parent group')} (#{groupName}) #{t('has')} #{groupCols} #{col_word}"
+      else
+        contextText = t('No parent group')
+
+      # Build card definitions
+      if groupCols is 4
+        cards = [
+          { slug: 'w4', label: t('Full width'),  pct: 100 }
+          { slug: 'w3', label: t('3/4 width'),   pct: 75  }
+          { slug: 'w2', label: t('Half width'),  pct: 50  }
+          { slug: 'w1', label: t('1/4 width'),   pct: 25  }
+        ]
+        defaultW = 'w4'
+      else
+        cards = for k in [1..groupCols]
+          { slug: "w#{k}", label: "#{k} of #{groupCols}", pct: Math.round(k / groupCols * 100) }
+        defaultW = "w#{groupCols}"
+
+      validSlugs = (c.slug for c in cards)
+      outOfRange = currentW? and currentW not in validSlugs
+      selectedW  = if outOfRange then null else if currentW? then currentW else defaultW
+
+      # --- Build DOM ---
+      $wrap = $('<div/>', { class: 'js-item-width-wrap item-width-subsection', style: 'grid-column: 1 / -1' })
+
+      # Header row (collapse toggle)
+      $header = $('<div/>', {
+        class: 'item-width__header js-item-width-toggle'
+        role: 'button'
+        tabindex: '0'
+        'aria-expanded': 'false'
+      })
+      $header.append($('<span/>', { class: 'item-width__title' }).text(t('Item width in group grid')))
+      $pill = $('<span/>', { class: 'js-item-width-pill item-width__pill', style: 'display:none' })
+      $header.append($pill)
+      $chev = $('<i/>', { class: 'k-icon k-icon-angle-down item-width__chev', 'aria-hidden': 'true' })
+      $header.append($chev)
+      $wrap.append($header)
+
+      # Context line — always visible (outside collapsible body)
+      $wrap.append($('<div/>', { class: 'item-width__context' }).text(contextText))
+
+      # Collapsible body — starts hidden
+      $body = $('<div/>', { class: 'js-item-width-body item-width__body' })
+
+      if groupCols isnt 4
+        $body.append($('<div/>', { class: 'item-width__span-note' }).text(
+          "#{t('This group has')} #{groupCols} #{t('columns, so widths are shown as columns.')}"
+        ))
+
+      $grid = $('<div/>', { class: 'item-width__grid' })
+      for card in cards
+        isSelected = card.slug is selectedW
+        $card = $('<div/>', {
+          class: "width-card#{if isSelected then ' is-selected' else ''}"
+          'data-width-slug': card.slug
+          role: 'button'
+          tabindex: '0'
+          'aria-pressed': "#{isSelected}"
+        })
+        if groupCols is 4
+          $card.append($("""<div class="bar-wrap"><div class="bar-fill#{if isSelected then ' sel-fill' else ''}" style="width:#{card.pct}%"></div></div>"""))
+        else
+          k = parseInt(card.slug.slice(1), 10)
+          segsHtml = (for i in [1..groupCols]
+            if i <= k then '<span class="on"></span>' else '<span></span>'
+          ).join('')
+          $card.append($("<div class=\"seg\">#{segsHtml}</div>"))
+        $card.append($('<div/>', { class: 'width-card__label' }).text(card.label))
+        $card.append($('<div/>', { class: 'width-card__code' }).text(card.slug))
+        $grid.append($card)
+      $body.append($grid)
+
+      if outOfRange
+        $body.append($('<div/>', { class: 'item-width__advisory' }).text(
+          "#{t('The saved width')} (#{currentW}) #{t('exceeds this group\'s')} #{groupCols} #{t('columns. Make a new selection to update it.')}"
+        ))
+
+      $body.hide()
+      $wrap.append($body)
+      $advBody.prepend($wrap)
+
+      @_refreshWidthPill($pill)
+      $pill.show()
+
+      # Card select handler
+      selectWidth = (el) =>
+        slug = $(el).data('width-slug')
+        @_writeWidthValue(slug)
+        $grid.find('.width-card').removeClass('is-selected').attr('aria-pressed', 'false')
+        $grid.find('.bar-fill').removeClass('sel-fill')
+        $(el).addClass('is-selected').attr('aria-pressed', 'true')
+        $(el).find('.bar-fill').addClass('sel-fill')
+        $body.find('.item-width__advisory').remove()
+        @_refreshWidthPill($pill)
+
+      $grid.off('click.oc-width').on 'click.oc-width', '.width-card', (evt) =>
+        selectWidth(evt.currentTarget)
+      $grid.off('keydown.oc-width').on 'keydown.oc-width', '.width-card', (evt) =>
+        selectWidth(evt.currentTarget) if evt.key in ['Enter', ' ']
+
+      # Collapse toggle
+      $header.off('click.widthToggle').on 'click.widthToggle', (evt) =>
+        evt.stopPropagation()
+        isCollapsed = $body.is(':hidden')
+        if isCollapsed
+          $body.show()
+          $header.attr('aria-expanded', 'true')
+          $pill.hide()
+        else
+          $body.hide()
+          $header.attr('aria-expanded', 'false')
+          @_refreshWidthPill($pill)
+          $pill.show()
+      $header.off('keydown.widthToggle').on 'keydown.widthToggle', (evt) =>
+        $header.trigger('click') if evt.key in ['Enter', ' ']
+
+    _writeWidthValue: (widthSlug) ->
+      currentVal = @model.get('value') or ''
+      stripped = currentVal.replace(/\bw\d+\b/g, '').replace(/\s+/g, ' ').trim()
+      newVal = if stripped then "#{stripped} #{widthSlug}" else widthSlug
+      @model.set('value', newVal)
+
+    _refreshWidthPill: ($pill) ->
+      groupCols = getParentGroupCols(@)
+      currentW  = getWidthFromModelValue(@model.get('value') or '')
+      unless currentW?
+        currentW = if groupCols is 4 then 'w4' else "w#{groupCols}"
+      label = buildWidthPillText(currentW, groupCols)
+      k = parseInt(currentW.slice(1), 10)
+      pct = Math.round(k / groupCols * 100)
+      $pill.empty()
+        .append($("""<span class="pill-bar"><span class="pill-fill" style="width:#{pct}%"></span></span>"""))
+        .append(document.createTextNode(" #{label} · #{currentW}"))
 
     # -------------------------------------------------------------------------
     # Helpers shared by both paths (kept from original)
@@ -1349,13 +1485,11 @@ module.exports = do ->
         input_value = $input.val().trim()
         model_set_value = input_value
 
-      select_width_value = @$select_width.val()
-      select_width_value = @select_width_default_value if select_width_value == 'select'
-      if model_set_value != ''
-        if select_width_value != ''
-          model_set_value += " #{select_width_value}"
-      else
-        model_set_value = select_width_value
+      # Preserve item width token managed by the Item width section
+      if @is_form_style_theme_grid()
+        existingWidth = getWidthFromModelValue(@model.get('value') or '')
+        if existingWidth
+          model_set_value = if model_set_value != '' then "#{model_set_value} #{existingWidth}" else existingWidth
 
       @model.set 'value', model_set_value
 
@@ -1375,13 +1509,19 @@ module.exports = do ->
       else
         model_set_value = input_value
 
-      select_width_value = @$select_width.val()
-      select_width_value = @select_width_default_value if select_width_value == 'select'
-      if model_set_value != ''
-        if select_width_value != ''
-          model_set_value += " #{select_width_value}"
-      else
-        model_set_value = select_width_value
+      if @model_is_group(@model)
+        # Group appearance: @$select_width sets the group's own column count
+        select_width_value = @$select_width.val()
+        select_width_value = @select_width_default_value if select_width_value == 'select'
+        if model_set_value != ''
+          model_set_value += " #{select_width_value}" if select_width_value != ''
+        else
+          model_set_value = select_width_value
+      else if @is_form_style_theme_grid()
+        # Non-group textbox: preserve item width token
+        existingWidth = getWidthFromModelValue(@model.get('value') or '')
+        if existingWidth
+          model_set_value = if model_set_value != '' then "#{model_set_value} #{existingWidth}" else existingWidth
 
       @model.set 'value', model_set_value
 
@@ -1888,5 +2028,7 @@ module.exports = do ->
   viewRowDetail.parseAppearanceValue = parseAppearanceValue
   viewRowDetail.buildModelValue = buildModelValue
   viewRowDetail.buildPillText = buildPillText
+  viewRowDetail.getWidthFromModelValue = getWidthFromModelValue
+  viewRowDetail.buildWidthPillText = buildWidthPillText
 
   viewRowDetail

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1218,18 +1218,6 @@ module.exports = do ->
       # Render secondary control for initial state
       @_renderSecondaryControl(questionType)
 
-      # Width select (theme-grid form style only)
-      if @is_form_style_theme_grid()
-        $width_field = $("""<div class="card__settings__fields__field xlf-dv-width-row">
-          <label for="select-width">#{t('Width')}:</label>
-          <span class="settings__input"></span>
-        </div>""")
-        $width_field.find('.settings__input').append(@$select_width)
-        @$el.append($width_field)
-        width_val = @get_width_from_model_value()
-        @$select_width.val(width_val) if width_val?
-        @$select_width.on 'change', => @_writeModelValue()
-
       # Card click/keyboard — namespace so re-renders don't stack handlers
       selectCard = (el) =>
         slug = $(el).data('card-slug')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -531,3 +531,74 @@ do ->
 
     it 'custom with no text → "Custom"', ->
       expect(buildPillText('custom', null, null)).toBe('Custom')
+
+  ###############################################################
+  # Item width helpers: getWidthFromModelValue
+  ###############################################################
+  describe 'getWidthFromModelValue', ->
+    {getWidthFromModelValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'returns null for null', ->
+      expect(getWidthFromModelValue(null)).toBe(null)
+
+    it 'returns null for empty string', ->
+      expect(getWidthFromModelValue('')).toBe(null)
+
+    it 'returns null when no wN token present', ->
+      expect(getWidthFromModelValue('minimal')).toBe(null)
+
+    it 'returns w1 for "w1"', ->
+      expect(getWidthFromModelValue('w1')).toBe('w1')
+
+    it 'returns w4 for "w4"', ->
+      expect(getWidthFromModelValue('w4')).toBe('w4')
+
+    it 'returns w10 for "w10"', ->
+      expect(getWidthFromModelValue('w10')).toBe('w10')
+
+    it 'extracts wN from combined appearance value', ->
+      expect(getWidthFromModelValue('minimal w3')).toBe('w3')
+
+    it 'extracts wN when it appears first', ->
+      expect(getWidthFromModelValue('w2 minimal')).toBe('w2')
+
+    it 'returns last matched wN when multiple present (highest wins)', ->
+      # iterates w1..w10 in order, last match wins
+      result = getWidthFromModelValue('w2 w5')
+      expect(result).toBe('w5')
+
+  ###############################################################
+  # Item width helpers: buildWidthPillText
+  ###############################################################
+  describe 'buildWidthPillText', ->
+    {buildWidthPillText} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'null widthVal in G=4 → "Full width"', ->
+      expect(buildWidthPillText(null, 4)).toBe('Full width')
+
+    it 'w4 in G=4 → "Full width"', ->
+      expect(buildWidthPillText('w4', 4)).toBe('Full width')
+
+    it 'w3 in G=4 → "3/4 width"', ->
+      expect(buildWidthPillText('w3', 4)).toBe('3/4 width')
+
+    it 'w2 in G=4 → "Half width"', ->
+      expect(buildWidthPillText('w2', 4)).toBe('Half width')
+
+    it 'w1 in G=4 → "1/4 width"', ->
+      expect(buildWidthPillText('w1', 4)).toBe('1/4 width')
+
+    it 'out-of-range w5 in G=4 → "w5"', ->
+      expect(buildWidthPillText('w5', 4)).toBe('w5')
+
+    it 'w1 in G=5 → "1 of 5"', ->
+      expect(buildWidthPillText('w1', 5)).toBe('1 of 5')
+
+    it 'w3 in G=5 → "3 of 5"', ->
+      expect(buildWidthPillText('w3', 5)).toBe('3 of 5')
+
+    it 'w5 in G=5 → "5 of 5"', ->
+      expect(buildWidthPillText('w5', 5)).toBe('5 of 5')
+
+    it 'null widthVal in G=6 → "Full width"', ->
+      expect(buildWidthPillText(null, 6)).toBe('Full width')

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -567,6 +567,9 @@ do ->
       result = getWidthFromModelValue('w2 w5')
       expect(result).toBe('w5')
 
+    it 'does not match partial token: w11 returns null', ->
+      expect(getWidthFromModelValue('w11')).toBeNull()
+
   ###############################################################
   # Item width helpers: buildWidthPillText
   ###############################################################


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Replaces the old w1–w10 text dropdown in the form designer's Advanced settings with a visual card-based width picker for questions inside a grid-layout group.

Shows 4 cards (Full / ¾ / Half / ¼ width) for a 4-column group, or N-of-N cards when the group has a custom column count (e.g. w3 → "1 of 3", "2 of 3", "3 of 3").

https://jira.openclinica.com/browse/OC-28006

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
