### PR TITLE
OC-27680 Required fields should not be in Advanced Options

### DIFF
--- a/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
@@ -132,6 +132,8 @@
     }
   }
 
+  &.xlf-dv-name,
+  &.xlf-dv-oc_item_group,
   &.xlf-dv-oc_external {
     label {
       vertical-align: top;
@@ -538,4 +540,12 @@
         background: inherit;
         border-left: 0;
     }
+}
+
+.item-group-helper {
+  font-size: 12px;
+  font-weight: normal;
+  color: colors.$kobo-gray-40;
+  margin-top: 4px;
+  margin-left: 30%;
 }

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
@@ -542,10 +542,12 @@
     }
 }
 
-.item-group-helper {
-  font-size: 12px;
-  font-weight: normal;
-  color: colors.$kobo-gray-40;
-  margin-top: 4px;
-  margin-left: 30%;
+.card__settings__fields__field {
+  .item-group-helper {
+    font-size: 12px;
+    font-weight: normal;
+    color: colors.$kobo-gray-40;
+    margin-top: 4px;
+    margin-left: 30%;
+  }
 }

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -271,6 +271,7 @@ module.exports = do ->
       where[how || 'append'](@el)
     insertInDOM: (rowView)->
       advancedKeys = [
+
         'readonly'
       ]
 
@@ -1532,7 +1533,7 @@ module.exports = do ->
       viewRowDetail.Templates.textbox @cid, @model.key, t("Item Group"), 'text', 'Enter data set name'
     afterRender: ->
       @listenForInputChange()
-      $('<p/>', { class: 'item-group-helper' }).text(t('The Item Group is the data set this item is stored in. Items that share an Item Group are kept together in the data model and in data extracts.')).appendTo(@$el)
+      $('<p/>', { class: 'item-group-helper' }).text(t('The Item Group is the data set this item is stored in. Items that share an Item Group are kept together in the data model and in data extracts.')).insertAfter(@$el.find('.settings__input'))
       externalValue = @model._parent.getValue('bind::oc:external')
       if externalValue in ['clinicaldata', 'contactdata', 'identifier', 'signature']
         @removeFieldCheckCondition()

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -271,11 +271,11 @@ module.exports = do ->
       where[how || 'append'](@el)
     insertInDOM: (rowView)->
       advancedKeys = [
-        'oc_item_group'
         'readonly'
       ]
 
       rightColumnKeys = [
+        'oc_item_group'
         'oc_description'
         'oc_external'
       ]
@@ -1532,6 +1532,7 @@ module.exports = do ->
       viewRowDetail.Templates.textbox @cid, @model.key, t("Item Group"), 'text', 'Enter data set name'
     afterRender: ->
       @listenForInputChange()
+      $('<p/>', { class: 'item-group-helper' }).text(t('The Item Group is the data set this item is stored in. Items that share an Item Group are kept together in the data model and in data extracts.')).appendTo(@$el)
       externalValue = @model._parent.getValue('bind::oc:external')
       if externalValue in ['clinicaldata', 'contactdata', 'identifier', 'signature']
         @removeFieldCheckCondition()

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -377,7 +377,6 @@ do ->
 
     it 'oc_item_group insertInDOM() places field in the primary right column, not the advanced panel', ->
       viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
-      $rowView = $('<div/>')
       $primaryRight = $('<div class="js-card-settings-col-right"/>')
       $advanced = $('<div class="js-card-settings-row-options-advanced"/>')
       $default = $('<div class="default-parent"/>')
@@ -385,12 +384,11 @@ do ->
         primaryRowDetailParentRight: $primaryRight
         advancedRowDetailParent: $advanced
         defaultRowDetailParent: $default
-      viewInstance = $.extend({}, viewRowDetail.DetailViewMixins.oc_item_group, {
-        $el: $('<div/>')
+      mockInstance =
         modelKey: 'oc_item_group'
+        $el: $('<div/>')
         _insertInDOM: (target) -> target.append(@$el)
-      })
-      viewInstance.insertInDOM(mockRowView)
+      viewRowDetail.DetailView.prototype.insertInDOM.call(mockInstance, mockRowView)
       expect($primaryRight.children().length).toBe(1)
       expect($advanced.children().length).toBe(0)
 

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -375,6 +375,25 @@ do ->
       @mixin_ctx.html()
       expect(@mixin_ctx.fieldTab).toBe('active')
 
+    it 'oc_item_group insertInDOM() places field in the primary right column, not the advanced panel', ->
+      viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      $rowView = $('<div/>')
+      $primaryRight = $('<div class="js-card-settings-col-right"/>')
+      $advanced = $('<div class="js-card-settings-row-options-advanced"/>')
+      $default = $('<div class="default-parent"/>')
+      mockRowView =
+        primaryRowDetailParentRight: $primaryRight
+        advancedRowDetailParent: $advanced
+        defaultRowDetailParent: $default
+      viewInstance = $.extend({}, viewRowDetail.DetailViewMixins.oc_item_group, {
+        $el: $('<div/>')
+        modelKey: 'oc_item_group'
+        _insertInDOM: (target) -> target.append(@$el)
+      })
+      viewInstance.insertInDOM(mockRowView)
+      expect($primaryRight.children().length).toBe(1)
+      expect($advanced.children().length).toBe(0)
+
   describe 'view.rowDetail.DetailViewMixins: "oc_briefdescription" html()', ->
     beforeEach ->
       window.xlfHideWarnings = true


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Moved the Item Group field from the collapsed Advanced Options panel to the top of the right-hand column in main item settings, so it's always visible without extra clicks. Added a helper text beneath it explaining what an Item Group is.

Related issue 
https://jira.openclinica.com/browse/OC-27680

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
