### PR TITLE
OC-28092 Reposition the delete control in form designer

### DIFF
--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -163,16 +163,12 @@
     font-size: 18px;
     cursor: pointer;
     color: colors.$kobo-gray-500;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.15s ease, color 0.15s ease;
+    transition: color 0.15s ease;
   }
 
   &:hover,
   &:focus-within {
     .k-icon.k-icon-trash {
-      opacity: 1;
-      pointer-events: auto;
       color: colors.$kobo-red;
     }
   }

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -164,6 +164,7 @@
     cursor: pointer;
     color: colors.$kobo-gray-500;
     opacity: 0;
+    pointer-events: none;
     transition: opacity 0.15s ease, color 0.15s ease;
   }
 
@@ -171,6 +172,7 @@
   &:focus-within {
     .k-icon.k-icon-trash {
       opacity: 1;
+      pointer-events: auto;
       color: colors.$kobo-red;
     }
   }

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -139,13 +139,40 @@
     }
   }
 
+  .multioptions__option__row {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    padding-right: 28px;
+
+    div.editable-wrapper {
+      flex: 1 1 auto;
+      width: auto;
+    }
+
+    code {
+      flex: 0 0 25%;
+    }
+  }
+
   .k-icon.k-icon-trash {
     position: absolute;
-    left: -20px;
-    top: 8px;
-    color: colors.$kobo-red;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
     font-size: 18px;
     cursor: pointer;
+    color: colors.$kobo-gray-500;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease;
+  }
+
+  &:hover,
+  &:focus-within {
+    .k-icon.k-icon-trash {
+      opacity: 1;
+      color: colors.$kobo-red;
+    }
   }
 }
 

--- a/jsapp/xlform/src/view.choices.coffee
+++ b/jsapp/xlform/src/view.choices.coffee
@@ -122,7 +122,7 @@ module.exports = do ->
       @p = $("<input placeholder=\"#{t("No value")}\" class=\"js-cancel-select-row option-view-input\" dir=\"auto\">")
       @c = $("<code><input type=\"text\" class=\"js-option-name-input js-cancel-select-row\"></input></code>")
       @i = $("<code><input type=\"text\" class=\"js-option-image-input js-cancel-select-row\"></input></code>")
-      @d = $('<div>')
+      @d = $('<div class="multioptions__option__row">')
       @optionImageField = 'image'
       if @model
         @p.val @model.get("label") || 'Empty'
@@ -224,9 +224,9 @@ module.exports = do ->
       ).bind @
 
       @d.append(@pw)
-      @d.append(@t)
       @d.append(@c)
       @d.append(@i)
+      @d.append(@t)
       @$el.html(@d)
       return @
     keyupinput: (evt)->

--- a/jsapp/xlform/src/view.choices.templates.coffee
+++ b/jsapp/xlform/src/view.choices.templates.coffee
@@ -4,7 +4,7 @@ module.exports = do ->
       template = """<div class="card__addoptions js-card-add-options">
           <div class="card__addoptions__layer"></div>
             <ul><li class="multioptions__option  xlf-option-view xlf-option-view--depr">
-              <div><div tabIndex="0" class="editable-wrapper"><span class="editable editable-click">+ #{t("click to add another response...")}</span></div><code><label>#{t("Value:")}</label> <span>#{t("AUTOMATIC")}</span></code><code><label>#{t("Image:")}</label> <span>#{t("None")}</span></code></div>
+              <div class="multioptions__option__row"><div tabIndex="0" class="editable-wrapper"><span class="editable editable-click">+ #{t("click to add another response...")}</span></div><code><label>#{t("Value:")}</label> <span>#{t("AUTOMATIC")}</span></code><code><label>#{t("Image:")}</label> <span>#{t("None")}</span></code></div>
             </li></ul>
         </div>"""
       return template


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Repositioned the trash icon using position: absolute and added padding-right to the option row flex container, so both real option rows and the "click to add another response..." row have identical content widths.

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
