### PR TITLE
OC-28093 response list row grouping

### DIFF
--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -85,7 +85,7 @@
   margin-bottom: 4px;
   margin-left: 4px;
   position: relative;
-  border: variables.$thinBorderStyle;
+  border: 1px solid colors.$kobo-gray-400;
   border-radius: 4px;
   transition: background-color 0.1s ease, border-color 0.1s ease;
 
@@ -209,8 +209,7 @@
 
   &:hover,
   &:focus-within {
-    background-color: colors.$kobo-gray-100;
-    border-color: colors.$kobo-gray-500;
+    border-color: colors.$kobo-gray-700;
 
     .k-icon.k-icon-trash {
       opacity: 1;
@@ -222,11 +221,34 @@
 
 .card__addoptions {
   position: relative;
+
+  .multioptions__option {
+    border-style: dashed;
+
+    &:hover,
+    &:focus-within {
+      border-color: variables.$linkColor;
+    }
+
+    .multioptions__option__row {
+      padding: 6px 8px;
+    }
+
+    div.editable-wrapper {
+      border: none;
+      width: 100%;
+
+      span.editable {
+        color: variables.$linkColor;
+        font-weight: 600;
+      }
+    }
+  }
 }
 
 .card__addoptions__layer {
   cursor: pointer !important;
-  background: rgba(colors.$kobo-white, 0.5);
+  background: transparent;
   position: absolute;
   width: 100%;
   height: 100%;

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -163,16 +163,12 @@
     font-size: 18px;
     cursor: pointer;
     color: colors.$kobo-gray-500;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.15s ease, color 0.15s ease;
+    transition: color 0.15s ease;
   }
 
   &:hover,
   &:focus-within {
     .k-icon.k-icon-trash {
-      opacity: 1;
-      pointer-events: auto;
       color: colors.$kobo-red;
     }
   }

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -164,6 +164,7 @@
     cursor: pointer;
     color: colors.$kobo-gray-500;
     opacity: 0;
+    pointer-events: none;
     transition: opacity 0.15s ease, color 0.15s ease;
   }
 
@@ -171,6 +172,7 @@
   &:focus-within {
     .k-icon.k-icon-trash {
       opacity: 1;
+      pointer-events: auto;
       color: colors.$kobo-red;
     }
   }

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -50,11 +50,44 @@
 // Single/multiple select questions
 // ==========================================================================
 
+// ==========================================================================
+// Response list column headers
+// ==========================================================================
+
+.multioptions__header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-left: 5px;
+  padding: 0 29px 4px 4px;
+}
+
+.multioptions__header__col {
+  font-size: 11px;
+  font-weight: 600;
+  color: colors.$kobo-gray-700;
+  letter-spacing: 0.04em;
+
+  &--label {
+    flex: 1 1 auto;
+  }
+
+  &--value,
+  &--image {
+    flex: 0 0 25%;
+    margin-left: 3%;
+    text-align: right;
+  }
+}
+
 // .xlf-option-view BECOMES .multioptions__option
 .multioptions__option {
   margin-bottom: 4px;
   margin-left: 4px;
   position: relative;
+  border: variables.$thinBorderStyle;
+  border-radius: 4px;
+  transition: background-color 0.1s ease, border-color 0.1s ease;
 
   div.editable-wrapper {
     font-weight: 600;
@@ -143,15 +176,21 @@
     display: flex;
     align-items: center;
     flex-wrap: nowrap;
-    padding-right: 28px;
+    padding: 4px 28px 4px 4px;
 
     div.editable-wrapper {
       flex: 1 1 auto;
       width: auto;
+      border-color: #cbd5e1;
     }
 
     code {
       flex: 0 0 25%;
+
+      span,
+      input[type='text'] {
+        border-color: #cbd5e1;
+      }
     }
   }
 
@@ -170,6 +209,9 @@
 
   &:hover,
   &:focus-within {
+    background-color: colors.$kobo-gray-100;
+    border-color: colors.$kobo-gray-500;
+
     .k-icon.k-icon-trash {
       opacity: 1;
       pointer-events: auto;

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -139,13 +139,40 @@
     }
   }
 
+  .multioptions__option__row {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    padding-right: 28px;
+
+    div.editable-wrapper {
+      flex: 1 1 auto;
+      width: auto;
+    }
+
+    code {
+      flex: 0 0 25%;
+    }
+  }
+
   .k-icon.k-icon-trash {
     position: absolute;
-    left: -20px;
-    top: 8px;
-    color: colors.$kobo-red;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
     font-size: 18px;
     cursor: pointer;
+    color: colors.$kobo-gray-500;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease;
+  }
+
+  &:hover,
+  &:focus-within {
+    .k-icon.k-icon-trash {
+      opacity: 1;
+      color: colors.$kobo-red;
+    }
   }
 }
 

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -75,7 +75,7 @@
   &--value,
   &--image {
     flex: 0 0 25%;
-    margin-left: 3%;
+    margin-left: 2%;
     text-align: right;
   }
 }

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -181,7 +181,7 @@
     div.editable-wrapper {
       flex: 1 1 auto;
       width: auto;
-      border-color: #cbd5e1;
+      border-color: colors.$kobo-gray-400;
     }
 
     code {
@@ -189,7 +189,7 @@
 
       span,
       input[type='text'] {
-        border-color: #cbd5e1;
+        border-color: colors.$kobo-gray-400;
       }
     }
   }

--- a/jsapp/xlform/src/view.choices.coffee
+++ b/jsapp/xlform/src/view.choices.coffee
@@ -21,6 +21,11 @@ module.exports = do ->
       if cardText.find('.card__buttons__multioptions.js-expand-multioptions').length is 0
         cardText.prepend $.parseHTML($viewTemplates.row.expandChoiceList())
       @$el.html (@ul = $("<ul>", class: @ulClasses))
+      $header = $('<div class="multioptions__header">')
+      $header.append($('<span class="multioptions__header__col multioptions__header__col--label">').text(t('Label')))
+      $header.append($('<span class="multioptions__header__col multioptions__header__col--value">').text(t('Value')))
+      $header.append($('<span class="multioptions__header__col multioptions__header__col--image">').text(t('Image')))
+      @$el.prepend($header)
       if @row.get("type").get("rowType").specifyChoice
         for option, i in @model.options.models
           new OptionView(model: option, cl: @model).render().$el.appendTo @ul
@@ -59,7 +64,7 @@ module.exports = do ->
         i = @model.options.length
         @addEmptyOption("Option #{i+1}")
         @model.getSurvey()?.trigger('change')
-        @$el.children().eq(0).children().eq(i).find('input.option-view-input').select()
+        @ul.children().eq(i).find('input.option-view-input').select()
         setTimeout =>
           @ul.find('li').last().find('.editable-wrapper').trigger('click')
         , 1

--- a/jsapp/xlform/src/view.choices.coffee
+++ b/jsapp/xlform/src/view.choices.coffee
@@ -122,7 +122,7 @@ module.exports = do ->
       @p = $("<input placeholder=\"#{t("No value")}\" class=\"js-cancel-select-row option-view-input\" dir=\"auto\">")
       @c = $("<code><input type=\"text\" class=\"js-option-name-input js-cancel-select-row\"></input></code>")
       @i = $("<code><input type=\"text\" class=\"js-option-image-input js-cancel-select-row\"></input></code>")
-      @d = $('<div>')
+      @d = $('<div class="multioptions__option__row">')
       @optionImageField = 'image'
       if @model
         @p.val @model.get("label") || 'Empty'
@@ -224,9 +224,9 @@ module.exports = do ->
       ).bind @
 
       @d.append(@pw)
-      @d.append(@t)
       @d.append(@c)
       @d.append(@i)
+      @d.append(@t)
       @$el.html(@d)
       return @
     keyupinput: (evt)->

--- a/jsapp/xlform/src/view.choices.templates.coffee
+++ b/jsapp/xlform/src/view.choices.templates.coffee
@@ -4,7 +4,7 @@ module.exports = do ->
       template = """<div class="card__addoptions js-card-add-options">
           <div class="card__addoptions__layer"></div>
             <ul><li class="multioptions__option  xlf-option-view xlf-option-view--depr">
-              <div class="multioptions__option__row"><div tabIndex="0" class="editable-wrapper"><span class="editable editable-click">+ #{t("click to add another response...")}</span></div><code><span>#{t("AUTOMATIC")}</span></code><code><span>#{t("None")}</span></code></div>
+              <div class="multioptions__option__row"><div tabIndex="0" class="editable-wrapper"><span class="editable editable-click">+ #{t("Add response")}</span></div></div>
             </li></ul>
         </div>"""
       return template

--- a/jsapp/xlform/src/view.choices.templates.coffee
+++ b/jsapp/xlform/src/view.choices.templates.coffee
@@ -4,7 +4,7 @@ module.exports = do ->
       template = """<div class="card__addoptions js-card-add-options">
           <div class="card__addoptions__layer"></div>
             <ul><li class="multioptions__option  xlf-option-view xlf-option-view--depr">
-              <div class="multioptions__option__row"><div tabIndex="0" class="editable-wrapper"><span class="editable editable-click">+ #{t("click to add another response...")}</span></div><code><label>#{t("Value:")}</label> <span>#{t("AUTOMATIC")}</span></code><code><label>#{t("Image:")}</label> <span>#{t("None")}</span></code></div>
+              <div class="multioptions__option__row"><div tabIndex="0" class="editable-wrapper"><span class="editable editable-click">+ #{t("click to add another response...")}</span></div><code><span>#{t("AUTOMATIC")}</span></code><code><span>#{t("None")}</span></code></div>
             </li></ul>
         </div>"""
       return template

--- a/jsapp/xlform/src/view.choices.templates.coffee
+++ b/jsapp/xlform/src/view.choices.templates.coffee
@@ -4,7 +4,7 @@ module.exports = do ->
       template = """<div class="card__addoptions js-card-add-options">
           <div class="card__addoptions__layer"></div>
             <ul><li class="multioptions__option  xlf-option-view xlf-option-view--depr">
-              <div><div tabIndex="0" class="editable-wrapper"><span class="editable editable-click">+ #{t("click to add another response...")}</span></div><code><label>#{t("Value:")}</label> <span>#{t("AUTOMATIC")}</span></code><code><label>#{t("Image:")}</label> <span>#{t("None")}</span></code></div>
+              <div class="multioptions__option__row"><div tabIndex="0" class="editable-wrapper"><span class="editable editable-click">+ #{t("click to add another response...")}</span></div><code><label>#{t("Value:")}</label> <span>#{t("AUTOMATIC")}</span></code><code><label>#{t("Image:")}</label> <span>#{t("None")}</span></code></div>
             </li></ul>
         </div>"""
       return template


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Added column headers (Label, Value, Image) above the response list, wrapped each option row in a visually bounded border, highlighted the entire row on hover, and removed redundant "Value:" / "Image:" labels from the add-option preview row.

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
