### PR TITLE
OC-28193: Add Manage Languages toolbar button to Form Designer

### DIFF
--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -1138,9 +1138,7 @@ export default function EditableForm(props: EditableFormProps) {
             </bem.FormBuilderHeader__cell>
           )}
 
-          {state.asset?.asset_type === ASSET_TYPES.survey.id && (
-            <bem.FormBuilderHeader__cell m={'verticalRule'} />
-          )}
+          {state.asset?.asset_type === ASSET_TYPES.survey.id && <bem.FormBuilderHeader__cell m={'verticalRule'} />}
 
           <bem.FormBuilderHeader__cell>
             <Button

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -715,6 +715,8 @@ export default function EditableForm(props: EditableFormProps) {
     saveAsideSettings(asideSettings)
   }
 
+  function manageLanguages() {}
+
   function toggleAsideLayoutSettings(evt: React.TouchEvent<HTMLButtonElement>) {
     evt.currentTarget.blur()
     const asideSettings: AsideSettings = {
@@ -1121,6 +1123,24 @@ export default function EditableForm(props: EditableFormProps) {
           </bem.FormBuilderHeader__cell>
 
           <bem.FormBuilderHeader__cell m='verticalRule' />
+
+          {state.asset?.asset_type === ASSET_TYPES.survey.id && (
+            <bem.FormBuilderHeader__cell>
+              <Button
+                type='text'
+                size='m'
+                onClick={manageLanguages}
+                tooltip={t('Manage languages for this form')}
+                tooltipPosition='left'
+                startIcon='language'
+                label={t('Manage Languages')}
+              />
+            </bem.FormBuilderHeader__cell>
+          )}
+
+          {state.asset?.asset_type === ASSET_TYPES.survey.id && (
+            <bem.FormBuilderHeader__cell m={'verticalRule'} />
+          )}
 
           <bem.FormBuilderHeader__cell>
             <Button


### PR DESCRIPTION
## Summary
- Adds a "Manage Languages" control to the Form Designer toolbar, positioned immediately before "Add from Library"
- Visible only when editing a survey asset (`state.asset?.asset_type === ASSET_TYPES.survey.id`); hidden in all Library item editors (question/block/template)
- Click handler is an intentional no-op stub — wiring it to the existing "Manage Languages" modal (`TranslationSettings`) is scoped to a follow-up ticket

## Acceptance Criteria
- AC1: "Manage Languages" control visible in the Form Designer toolbar when editing a form ✅
- AC2: Editor interfaces for library items outside Form Designer do not show this control ✅

## Test plan
- [x] `npm run lint:types` — no new errors
- [x] `npx eslint 'jsapp/js/editorMixins/EditableForm.tsx'` — no new errors
- [x] `npm run test:unit` — 1352/1352 passing
- [x] Manually verified in a running local OC4 stack: button renders before "Add from Library" when editing a survey in Form Designer; does not render when editing a Library item