### PR TITLE
OC-28194: Set the form's primary language

### DIFF
--- a/jsapp/js/components/bigModal/bigModal.js
+++ b/jsapp/js/components/bigModal/bigModal.js
@@ -114,11 +114,11 @@ class BigModal extends React.Component {
         break
 
       case MODAL_TYPES.LIBRARY_COLLECTION_CREATE:
-        this.setState({ title: t('Create Collection'), modalClass: 'modal--top-aligned' })
+        this.setState({ title: t('Create Collection'), modalClass: 'modal--top-aligned modal--oc' })
         break
 
       case MODAL_TYPES.LIBRARY_COLLECTION_EDIT:
-        this.setState({ title: t('Edit Collection'), modalClass: 'modal--top-aligned' })
+        this.setState({ title: t('Edit Collection'), modalClass: 'modal--top-aligned modal--oc' })
         break
 
       case MODAL_TYPES.ASSET_TAGS:
@@ -169,7 +169,7 @@ class BigModal extends React.Component {
         break
 
       case MODAL_TYPES.FORM_LANGUAGES:
-        this.setState({ modalClass: 'modal--form-languages' })
+        this.setState({ modalClass: 'modal--oc' })
         break
 
       case MODAL_TYPES.FORM_TRANSLATIONS_TABLE:

--- a/jsapp/js/components/bigModal/bigModal.js
+++ b/jsapp/js/components/bigModal/bigModal.js
@@ -169,7 +169,7 @@ class BigModal extends React.Component {
         break
 
       case MODAL_TYPES.FORM_LANGUAGES:
-        this.setModalTitle(t('Manage Languages'))
+        this.setState({ modalClass: 'modal--form-languages' })
         break
 
       case MODAL_TYPES.FORM_TRANSLATIONS_TABLE:
@@ -257,6 +257,12 @@ class BigModal extends React.Component {
         var filename = props.params.filename || ''
         newState.title = t('Uploading XLS file')
         newState.message = t('Uploading: ') + filename
+      }
+
+      if (props.params.type === MODAL_TYPES.FORM_LANGUAGES) {
+        const translations = props.params.asset?.content?.translations
+        const isSettingPrimaryLanguage = translations?.length === 1 && translations[0] === null
+        newState.title = isSettingPrimaryLanguage ? t('Select a primary language') : t('Manage Languages')
       }
 
       // store for later

--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -299,14 +299,13 @@ $modal-custom-header-height: 60px;
   }
 }
 
-.modal.modal--form-languages {
+// Shared "OpenClinica" chrome: rounded corners + a bit more breathing room
+// around the title/close-icon/body than the base modal. Plain white header
+// (inherits the base `.modal__header` styling) — no color override. Apply
+// this alongside any modal-specific class (sizing, positioning, etc.).
+.modal.modal--oc {
   border-radius: 12px;
-  overflow: hidden; // so the header's color respects the rounded top corners
-
-  .modal__header {
-    background-color: colors.$kobo-hover-blue;
-    color: colors.$kobo-white;
-  }
+  overflow: hidden;
 
   .modal__title {
     font-size: 18px;
@@ -314,12 +313,23 @@ $modal-custom-header-height: 60px;
   }
 
   .modal__x {
-    color: colors.$kobo-white;
     margin: 10px;
   }
 
   .modal__body {
     padding-top: 20px;
+  }
+
+  // Bumps the Create/Edit Collection field label ("Please enter the name of
+  // your new Collection...") up from the shared TextBox component's default
+  // 12px, and gives it more breathing room above the input box (default is
+  // just 3px). Scoped to `.modal--oc` so it doesn't affect TextBox usage
+  // elsewhere in the app; structural (not a CSS-module class) since
+  // textBox.module.scss's hashed class names aren't stable to select from
+  // outside the component.
+  .library-asset-form label > div:first-child {
+    font-size: 14px;
+    margin-bottom: 12px;
   }
 }
 

--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -310,11 +310,12 @@ $modal-custom-header-height: 60px;
 
   .modal__title {
     font-size: 18px;
-    padding: 15px 10px;
+    padding: 15px;
   }
 
   .modal__x {
     color: colors.$kobo-white;
+    margin: 10px;
   }
 
   .modal__body {

--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -299,6 +299,29 @@ $modal-custom-header-height: 60px;
   }
 }
 
+.modal.modal--form-languages {
+  border-radius: 12px;
+  overflow: hidden; // so the header's color respects the rounded top corners
+
+  .modal__header {
+    background-color: colors.$kobo-hover-blue;
+    color: colors.$kobo-white;
+  }
+
+  .modal__title {
+    font-size: 18px;
+    padding: 15px 10px;
+  }
+
+  .modal__x {
+    color: colors.$kobo-white;
+  }
+
+  .modal__body {
+    padding-top: 20px;
+  }
+}
+
 .enketo-holder {
   // resets modal window paddings
   margin: 0 -20px;

--- a/jsapp/js/components/modalForms/TranslationSettings.tsx
+++ b/jsapp/js/components/modalForms/TranslationSettings.tsx
@@ -13,11 +13,8 @@ import { hasAssetRestriction } from '#/components/locking/lockingUtils'
 import LanguageForm from '#/components/modalForms/languageForm'
 import { MODAL_TYPES } from '#/constants'
 import type { AssetContent, AssetResponse, SureveyRowOrChoiceTranslatableProp, SurveyRow } from '#/dataInterface'
-import envStore from '#/envStore'
 import pageState from '#/pageState.store'
 import { type LangObject, escapeHtml, getLangString, notify } from '#/utils'
-
-const LANGUAGE_SUPPORT_URL = 'language_dashboard.html'
 
 interface TranslationSettingsProps {
   asset: AssetResponse
@@ -245,8 +242,8 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
 
     const dialog = alertify.dialog('confirm')
     const opts = {
-      title: t('Change default language?'),
-      message: t('Are you sure you would like to set ##lang## as the default language for this form?').replace(
+      title: t('Change primary language?'),
+      message: t('Are you sure you would like to set ##lang## as the primary language for this form?').replace(
         '##lang##',
         escapeHtml(String(langString)),
       ),
@@ -301,27 +298,10 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
       <bem.FormModal m='translation-settings'>
         <bem.FormModal__item>
           <bem.FormView__cell m='translation-note'>
-            <p>{t('Here you can add more languages to your project, and translate the strings in each of them.')}</p>
             <p>
-              {t('For the language code field, we suggest using the')}
-              <a
-                target='_blank'
-                href='https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry'
-              >
-                {' ' + t('official language code') + ' '}
-              </a>
-              {t('(e.g. "English (en)" or "Rohingya (rhg)").')}
-
-              {envStore.isReady && envStore.data.support_url && (
-                <a target='_blank' href={envStore.data.support_url + LANGUAGE_SUPPORT_URL}>
-                  {' ' + t('Read more.')}
-                </a>
+              {t(
+                'Setting a primary language is required. This is the language you have entered in the main Form Designer interface. Provide the official language code. For example, if this form is primarily authored in English, enter "English" and "en". It does not necessarily determine which language the form will use during data collection.',
               )}
-            </p>
-          </bem.FormView__cell>
-          <bem.FormView__cell m='translation'>
-            <p>
-              <strong>{t('Please name your default language before adding languages and translations.')}</strong>
             </p>
           </bem.FormView__cell>
           <bem.FormView__cell m='update-language-form'>
@@ -329,6 +309,7 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
               isPending={this.state.isUpdatingAsset}
               onLanguageChange={this.onLanguageChange.bind(this)}
               existingLanguages={this.getAllLanguages()}
+              langString='English (en)'
               isDefault
             />
           </bem.FormView__cell>
@@ -347,7 +328,7 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
               type='warning'
               icon='alert'
               message={t(
-                'You have named translations in your form but the default translation is unnamed. Please specifiy a default translation or make an existing one default.',
+                'You have named translations in your form but the primary translation is unnamed. Please specify a primary translation or make an existing one primary.',
               )}
             />
           )}
@@ -357,7 +338,7 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
                 <bem.FormView__cell m='translation-name'>
                   {l}
 
-                  {i === 0 && <bem.FormView__label m='default-language'>{t('default')}</bem.FormView__label>}
+                  {i === 0 && <bem.FormView__label m='default-language'>{t('primary')}</bem.FormView__label>}
 
                   {i !== 0 && (
                     <Button
@@ -367,7 +348,7 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
                         this.changeDefaultLanguage(i)
                       }}
                       isDisabled={this.state.isUpdatingAsset || !this.canEditLanguages()}
-                      tooltip={t('Make default')}
+                      tooltip={t('Make primary')}
                       startIcon='language-default'
                     />
                   )}

--- a/jsapp/js/components/modalForms/languageForm.js
+++ b/jsapp/js/components/modalForms/languageForm.js
@@ -138,14 +138,14 @@ class LanguageForm extends React.Component {
       <bem.FormView__form m='add-language-fields'>
         <bem.FormView__cell m='lang-name'>
           <bem.FormModal__item>
-            <label>{this.props.isDefault ? t('Default language name') : t('Language name')}</label>
+            <label>{this.props.isDefault ? t('Primary language name') : t('Language name')}</label>
             <TextBox value={this.state.name} onChange={this.onNameChange.bind(this)} errors={this.state.nameError} />
           </bem.FormModal__item>
         </bem.FormView__cell>
 
         <bem.FormView__cell m='lang-code'>
           <bem.FormModal__item>
-            <label>{this.props.isDefault ? t('Default language code') : t('Language code')}</label>
+            <label>{this.props.isDefault ? t('Primary language code') : t('Language code')}</label>
             <TextBox value={this.state.code} onChange={this.onCodeChange.bind(this)} errors={this.state.codeError} />
           </bem.FormModal__item>
         </bem.FormView__cell>

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -1138,9 +1138,7 @@ export default function EditableForm(props: EditableFormProps) {
             </bem.FormBuilderHeader__cell>
           )}
 
-          {state.asset?.asset_type === ASSET_TYPES.survey.id && (
-            <bem.FormBuilderHeader__cell m={'verticalRule'} />
-          )}
+          {state.asset?.asset_type === ASSET_TYPES.survey.id && <bem.FormBuilderHeader__cell m={'verticalRule'} />}
 
           <bem.FormBuilderHeader__cell>
             <Button

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -715,6 +715,8 @@ export default function EditableForm(props: EditableFormProps) {
     saveAsideSettings(asideSettings)
   }
 
+  function manageLanguages() {}
+
   function toggleAsideLayoutSettings(evt: React.TouchEvent<HTMLButtonElement>) {
     evt.currentTarget.blur()
     const asideSettings: AsideSettings = {
@@ -1121,6 +1123,24 @@ export default function EditableForm(props: EditableFormProps) {
           </bem.FormBuilderHeader__cell>
 
           <bem.FormBuilderHeader__cell m='verticalRule' />
+
+          {state.asset?.asset_type === ASSET_TYPES.survey.id && (
+            <bem.FormBuilderHeader__cell>
+              <Button
+                type='text'
+                size='m'
+                onClick={manageLanguages}
+                tooltip={t('Manage languages for this form')}
+                tooltipPosition='left'
+                startIcon='language'
+                label={t('Manage Languages')}
+              />
+            </bem.FormBuilderHeader__cell>
+          )}
+
+          {state.asset?.asset_type === ASSET_TYPES.survey.id && (
+            <bem.FormBuilderHeader__cell m={'verticalRule'} />
+          )}
 
           <bem.FormBuilderHeader__cell>
             <Button

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -43,6 +43,7 @@ import {
   AssetTypeName,
   type FormStyleDefinition,
   type FormStyleName,
+  MODAL_TYPES,
   NAME_MAX_LENGTH,
   OC_USER_TYPES,
   QuestionTypeName,
@@ -50,6 +51,7 @@ import {
   update_states,
 } from '#/constants'
 import envStore from '#/envStore'
+import pageState from '#/pageState.store'
 import type { RouterProp } from '#/router/legacy'
 import { ROUTES } from '#/router/routerConstants'
 import sessionStore from '#/stores/session'
@@ -715,7 +717,14 @@ export default function EditableForm(props: EditableFormProps) {
     saveAsideSettings(asideSettings)
   }
 
-  function manageLanguages() {}
+  function manageLanguages() {
+    if (state.asset) {
+      pageState.showModal({
+        type: MODAL_TYPES.FORM_LANGUAGES,
+        asset: state.asset,
+      })
+    }
+  }
 
   function toggleAsideLayoutSettings(evt: React.TouchEvent<HTMLButtonElement>) {
     evt.currentTarget.blur()


### PR DESCRIPTION
> [!WARNING]
> **Depends on #268 (OC-28193).** This branch is built on top of `OC-28193-manage-languages-toolbar-button`, which hasn't merged yet, so this diff currently includes #268's commits too. **Please merge #268 first** — once it lands on `master`, this PR's diff will automatically shrink to just this ticket's 3 commits. Reviewing this PR before #268 merges will show OC-28193's changes as part of the diff, which isn't the intent.

## Summary
- Wires the "Manage Languages" toolbar button (added in #268) to the existing "Manage Languages" modal
- AC1: primary-language setup screen, prepopulated "English"/"en"
- AC2: explanatory copy (authoring language vs. data-collection language), matching the design mockup's wording
- AC3/AC4/AC5: already satisfied by existing, unmodified upstream code (verified structurally, not just by report) — "Add language" and the translation table stay gated until a primary language is set, and forms that already have one skip straight to the language list
- Renames remaining "default language" UI text to "primary language" for consistency, without touching the underlying `default_language` data field or `changeDefaultLanguage()` identifier
- Restyles the modal's chrome (blue header, rounded corners, larger title) scoped to just this modal via a new `modal--form-languages` variant class — no other modal type is affected
- Makes the modal title dynamic ("Select a primary language" → "Manage Languages") without requiring the modal to be closed and reopened

## Test plan
- [x] `npm run lint:types` — no new errors
- [x] `npx eslint` — no new errors
- [x] `npx biome check` — no errors (note: biome does not process `.scss` files)
- [x] `npm run test:unit` — 1352/1352 passing
- [x] Manually verified in a running local OC4 stack: setup screen → prepopulated fields → submit → title flips to "Manage Languages" in place → language shown with "primary" pill; a survey with an existing primary language opens straight to the list; other modals (e.g. Library item "Edit label(s)") unaffected by the chrome restyle