### PR TITLE
OC-28234 Show Columns in Grid picker above appearance cards for groups

### DIFF
--- a/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
@@ -224,10 +224,23 @@
   margin-right: 60px;
 }
 
-// Group panel: appearance is a sibling of the tab panels, not nested inside row-options,
-// so hide it when row-options is inactive.
-.js-card-settings-row-options:not(.card__settings__fields--active) ~ .js-card-settings-appearance {
+// Group panel: appearance and columns-in-grid are siblings of the tab panels,
+// so hide them when row-options is inactive.
+.js-card-settings-row-options:not(.card__settings__fields--active) ~ .js-card-settings-appearance,
+.js-card-settings-row-options:not(.card__settings__fields--active) ~ .js-group-cols-wrap {
   display: none;
+}
+
+// When Columns in Grid follows a collapsed Appearance section, suppress the redundant
+// top border (the Appearance header already has border-bottom acting as the divider).
+// When Appearance is expanded its body is visible, so restore the border to separate them.
+.card__settings__appearance-section + .card__settings__appearance-section {
+  border-top: none;
+  margin-top: 0;
+}
+
+.card__settings__appearance-section:not(.is-collapsed) + .card__settings__appearance-section {
+  border-top: 1px solid #CBD5E1;
 }
 
 // Group type: always 3 columns (single row)

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1203,10 +1203,6 @@ module.exports = do ->
       $pill    = $section.find('.js-appearance-pill').eq(0)
       $toggle  = $section.find('.js-appearance-toggle').eq(0)
 
-      # For groups: render columns picker first so it appears above the appearance cards
-      if questionType is 'group'
-        @_afterRenderGroupCols(@get_width_from_model_value())
-
       # Build card grid — clear any prior grid before re-rendering
       @$el.find('.card__settings__appearance-grid').remove()
       cards = getAppearanceCards(questionType)
@@ -1241,8 +1237,10 @@ module.exports = do ->
       @$el.off('keydown.oc-appearance').on 'keydown.oc-appearance', '.appearance-card', (evt) =>
         selectCard(evt.currentTarget) if evt.key in ['Enter', ' ']
 
-      # For non-groups: item width picker (appears after the appearance cards)
-      unless questionType is 'group'
+      # For groups: Columns in Grid as own section after Appearance; for non-groups: item width picker
+      if questionType is 'group'
+        @_afterRenderGroupCols(@get_width_from_model_value())
+      else
         @_afterRenderWidth()
 
       # Initial pill (section starts collapsed)
@@ -1610,7 +1608,7 @@ module.exports = do ->
 
     _afterRenderGroupCols: (storedVal) ->
       return unless @is_form_style_theme_grid()
-      @$el.find('.js-group-cols-wrap').remove()
+      @rowView.cardSettingsWrap.find('.js-group-cols-wrap').remove()
 
       DEFAULT_COLS = 4
       currentSelCols = null
@@ -1619,22 +1617,21 @@ module.exports = do ->
         currentSelCols = parsed unless isNaN(parsed) or parsed < 1 or parsed > 10
       outOfRange = storedVal? and storedVal isnt '' and currentSelCols is null
 
-      $wrap = $('<div/>', { class: 'js-group-cols-wrap card__settings__fields__field group-cols-section' })
-      $wrap.append($('<label/>').text(t('Columns in Grid') + ':'))
+      $wrap = $('<div/>', { class: 'js-group-cols-wrap card__settings__appearance-section is-collapsed' })
 
-      $settingsInput = $('<span/>', { class: 'settings__input' })
-
-      $header = $('<button/>', {
-        class: 'group-cols__header'
-        type: 'button'
+      $header = $('<div/>', {
+        class: 'card__settings__appearance-header js-group-cols-toggle'
+        role: 'button'
+        tabindex: '0'
         'aria-expanded': 'false'
       })
-      $pill = $('<span/>', { class: 'js-group-cols-pill group-cols__pill' })
+      $header.append($('<span/>', { class: 'card__settings__appearance-title' }).text(t('Columns in Grid')))
+      $pill = $('<span/>', { class: 'js-group-cols-pill card__settings__appearance-pill' })
       $header.append($pill)
-      $header.append($('<i/>', { class: 'k-icon k-icon-angle-down group-cols__chev', 'aria-hidden': 'true' }))
-      $settingsInput.append($header)
+      $header.append($('<i/>', { class: 'k-icon k-icon-angle-down card__settings__appearance-toggle__icon', 'aria-hidden': 'true' }))
+      $wrap.append($header)
 
-      $body = $('<div/>', { class: 'js-group-cols-body group-cols__body' })
+      $body = $('<div/>', { class: 'js-group-cols-body card__settings__appearance-body' })
       $body.append(
         $('<p/>', { class: 'group-cols__instruction' }).text(
           t('Sets how many columns items in this group are arranged into.')
@@ -1666,10 +1663,8 @@ module.exports = do ->
           )
         )
 
-      $body.hide()
-      $settingsInput.append($body)
-      $wrap.append($settingsInput)
-      @$el.append($wrap)
+      $wrap.append($body)
+      @rowView.cardSettingsWrap.find('.js-card-settings-appearance').eq(0).after($wrap)
 
       refreshPill = =>
         numCols = currentSelCols ? DEFAULT_COLS
@@ -1677,6 +1672,7 @@ module.exports = do ->
         $pill.text(if currentSelCols? then "#{numCols} #{colWord} · w#{numCols}" else "#{numCols} #{colWord}")
 
       refreshPill()
+      $pill.show()
 
       selectCols = (el) =>
         numCols = parseInt($(el).data('cols'), 10)
@@ -1702,18 +1698,23 @@ module.exports = do ->
           evt.stopPropagation()
           selectCols(evt.currentTarget)
 
-      $header.off('click.groupColsToggle').on 'click.groupColsToggle', (evt) =>
-        evt.stopPropagation()
-        isCollapsed = $body.is(':hidden')
-        if isCollapsed
-          $body.show()
-          $header.attr('aria-expanded', 'true')
-          $pill.hide()
-        else
-          $body.hide()
-          $header.attr('aria-expanded', 'false')
-          refreshPill()
-          $pill.show()
+      $header.off('click.groupColsToggle keydown.groupColsToggle')
+        .on 'click.groupColsToggle', (evt) =>
+          evt.stopPropagation()
+          isCollapsed = $wrap.hasClass('is-collapsed')
+          if isCollapsed
+            $wrap.removeClass('is-collapsed')
+            $header.attr('aria-expanded', 'true')
+            $pill.hide()
+          else
+            $wrap.addClass('is-collapsed')
+            $header.attr('aria-expanded', 'false')
+            refreshPill()
+            $pill.show()
+        .on 'keydown.groupColsToggle', (evt) =>
+          if evt.key in ['Enter', ' ']
+            evt.preventDefault()
+            $header.trigger('click')
 
     _writeWidthValue: (widthSlug) ->
       currentVal = @model.get('value') or ''

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1235,7 +1235,9 @@ module.exports = do ->
       @$el.off('click.oc-appearance').on 'click.oc-appearance', '.appearance-card', (evt) =>
         selectCard(evt.currentTarget)
       @$el.off('keydown.oc-appearance').on 'keydown.oc-appearance', '.appearance-card', (evt) =>
-        selectCard(evt.currentTarget) if evt.key in ['Enter', ' ']
+        if evt.key in ['Enter', ' ']
+          evt.preventDefault()
+          selectCard(evt.currentTarget)
 
       # For groups: Columns in Grid as own section after Appearance; for non-groups: item width picker
       if questionType is 'group'

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1195,6 +1195,10 @@ module.exports = do ->
       @_columnCount = columnCount
       @_customText = customText
 
+      # Sync @$select_width with any saved column count so card clicks preserve it
+      currentWidth = @get_width_from_model_value()
+      @$select_width.val(currentWidth) if currentWidth?
+
       $section = @rowView.cardSettingsWrap.find('.js-card-settings-appearance').eq(0)
       $pill    = $section.find('.js-appearance-pill').eq(0)
       $toggle  = $section.find('.js-appearance-toggle').eq(0)

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1199,6 +1199,10 @@ module.exports = do ->
       $pill    = $section.find('.js-appearance-pill').eq(0)
       $toggle  = $section.find('.js-appearance-toggle').eq(0)
 
+      # For groups: render columns picker first so it appears above the appearance cards
+      if questionType is 'group'
+        @_afterRenderGroupCols(@get_width_from_model_value())
+
       # Build card grid — clear any prior grid before re-rendering
       @$el.find('.card__settings__appearance-grid').remove()
       cards = getAppearanceCards(questionType)
@@ -1233,8 +1237,9 @@ module.exports = do ->
       @$el.off('keydown.oc-appearance').on 'keydown.oc-appearance', '.appearance-card', (evt) =>
         selectCard(evt.currentTarget) if evt.key in ['Enter', ' ']
 
-      # Item width section
-      @_afterRenderWidth()
+      # For non-groups: item width picker (appears after the appearance cards)
+      unless questionType is 'group'
+        @_afterRenderWidth()
 
       # Initial pill (section starts collapsed)
       @_refreshPill($pill)
@@ -1673,7 +1678,10 @@ module.exports = do ->
         numCols = parseInt($(el).data('cols'), 10)
         currentSelCols = numCols
         @$select_width.val("w#{numCols}")
-        @group_inputs_change_handler()
+        if @_card?
+          @_writeModelValue()
+        else
+          @group_inputs_change_handler()
         $grid.find('.group-cols-card').each ->
           $c = $(@)
           cn = parseInt($c.data('cols'), 10)


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixed a bug where the "Columns in Grid" picker was not appearing in group settings when Grid layout was enabled.

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
