### PR TITLE
OC-28235 Show calculation tab red indicator only for calculate type i…

### DIFF
--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -800,11 +800,9 @@ module.exports = do ->
               $calcTabError.removeClass('calculation-tab__error--hidden')
             else
               $calcTabError.addClass('calculation-tab__error--hidden')
-          $calcTextarea.on('blur', updateCalcTabError)
-          $calcTextarea.on('keyup', updateCalcTabError)
+          $calcTextarea.on('blur input', updateCalcTabError)
           updateCalcTabError()
 
-        if questionType is 'calculate'
           makeRequiredCheck = ->
             $field = $calcTextarea.closest('.calculation-panel__field')
             if ($calcTextarea.val() or '').trim() is ''
@@ -815,8 +813,7 @@ module.exports = do ->
             else
               $field.removeClass('input-error')
               $calcTextarea.siblings('.message').remove()
-          $calcTextarea.on('blur', makeRequiredCheck)
-          $calcTextarea.on('keyup', makeRequiredCheck)
+          $calcTextarea.on('blur input', makeRequiredCheck)
 
         if triggerModel
           $select = $calcPanel.find('.js-calculation-trigger-select')

--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -793,15 +793,16 @@ module.exports = do ->
             evt.preventDefault()
             $calcTextarea.blur()
 
-        $calcTabError = @cardSettingsWrap.find('.js-calculation-tab-error')
-        updateCalcTabError = ->
-          if ($calcTextarea.val() or '').trim() is ''
-            $calcTabError.removeClass('calculation-tab__error--hidden')
-          else
-            $calcTabError.addClass('calculation-tab__error--hidden')
-        $calcTextarea.on('blur', updateCalcTabError)
-        $calcTextarea.on('keyup', updateCalcTabError)
-        updateCalcTabError()
+        if questionType is 'calculate'
+          $calcTabError = @cardSettingsWrap.find('.js-calculation-tab-error')
+          updateCalcTabError = ->
+            if ($calcTextarea.val() or '').trim() is ''
+              $calcTabError.removeClass('calculation-tab__error--hidden')
+            else
+              $calcTabError.addClass('calculation-tab__error--hidden')
+          $calcTextarea.on('blur', updateCalcTabError)
+          $calcTextarea.on('keyup', updateCalcTabError)
+          updateCalcTabError()
 
         if questionType is 'calculate'
           makeRequiredCheck = ->


### PR DESCRIPTION
…tems

### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixed a bug where the Calculation panel's red "!" badge appeared for all question types whenever the calculation field was empty. The indicator now only shows for calculate type items, matching the AC.

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
