### PR TITLE
OC-28246: Add AI Generate button + dialog to Form Designer panels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@
 FROM node:20.19-bookworm-slim AS npm-install
 WORKDIR /srv/src/kpi
 
+# OC fork: git + CA certs so `npm clean-install` can fetch the private
+# @openclinica/logic-builder git dependency (the slim image ships neither).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 # This is our non-root user 1000.
 RUN chown node:node .
 
@@ -53,8 +59,19 @@ COPY --chown=node:node --parents \
 # Run npm clean-install as non-root user,
 # and clean the cache for space.
 USER node
-RUN npm clean-install \
-    && npm cache clean --force
+# OC fork: authenticate the private @openclinica/logic-builder clone with a
+# BuildKit secret (Jenkins passes `--secret id=gh_token`). The token is written
+# only to a throwaway gitconfig deleted before this layer is committed, so it
+# never persists in the image; it rewrites the lockfile's git+ssh URL to
+# token-authenticated HTTPS. The final `test -d` fails the build if the real
+# package didn't install — so an image can never silently ship without it.
+RUN --mount=type=secret,id=gh_token,uid=1000 \
+    export GIT_CONFIG_GLOBAL=/tmp/gitconfig \
+    && git config --global url."https://x-access-token:$(cat /run/secrets/gh_token)@github.com/".insteadOf "ssh://git@github.com/" \
+    && npm clean-install \
+    && npm cache clean --force \
+    && rm -f /tmp/gitconfig \
+    && test -d node_modules/@openclinica/logic-builder/dist
 
 # Results in /srv/src/kpi/:
 #   All the sources copied above, plus the generated:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,15 +43,21 @@ pipeline {
                 DEBIAN_FRONTEND = 'noninteractive'
             }
             steps {
-                sh '''
-                    set -e
-                    apt-get update -qq
-                    apt-get install -y --no-install-recommends python3
-                    ln -sf /usr/bin/python3 /usr/bin/python
-                    rm -rf /var/lib/apt/lists/*
-                    npm ci --legacy-peer-deps --cache /tmp/.npm-cache
-                    npm run test:unit
-                '''
+                // OC fork: authenticate the private @openclinica/logic-builder clone.
+                // Single-quoted sh body -> ${GH_TOKEN} expands in the shell from the
+                // masked credential env var, never in Groovy (so it isn't logged).
+                withCredentials([string(credentialsId: 'jenkins-github-token-as-password', variable: 'GH_TOKEN')]) {
+                    sh '''
+                        set -e
+                        apt-get update -qq
+                        apt-get install -y --no-install-recommends python3 git
+                        ln -sf /usr/bin/python3 /usr/bin/python
+                        rm -rf /var/lib/apt/lists/*
+                        git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+                        npm ci --legacy-peer-deps --cache /tmp/.npm-cache
+                        npm run test:unit
+                    '''
+                }
             }
         }
 
@@ -83,7 +89,14 @@ pipeline {
                         docker buildx create --name arm64builder --node arm64 --platform linux/aarch64
                         docker buildx inspect --bootstrap --builder arm64builder
                        """
-                    sh "docker buildx build --builder arm64builder --platform linux/aarch64 -t ${registry}:${tag_version} --push ."
+                    // OC fork: pass the GitHub token to BuildKit as a secret so the
+                    // Dockerfile's npm-install stage can clone the private
+                    // @openclinica/logic-builder (id must match the Dockerfile's
+                    // `--mount=type=secret,id=gh_token`). `env=GH_TOKEN` reads it from
+                    // the masked credential env var, so it never appears in the log.
+                    withCredentials([string(credentialsId: 'jenkins-github-token-as-password', variable: 'GH_TOKEN')]) {
+                        sh "docker buildx build --builder arm64builder --platform linux/aarch64 --secret id=gh_token,env=GH_TOKEN -t ${registry}:${tag_version} --push ."
+                    }
                   }
                 else {
                     sh "echo 'Skipping this step'" 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,12 @@ pipeline {
                         apt-get install -y --no-install-recommends python3 git
                         ln -sf /usr/bin/python3 /usr/bin/python
                         rm -rf /var/lib/apt/lists/*
+                        # Scope the token to a throwaway gitconfig (never the persistent
+                        # ~/.gitconfig, which can linger with reuseNode). GIT_CONFIG_GLOBAL
+                        # points git — and the git children npm spawns — at it; the trap
+                        # wipes it on exit, success or failure.
+                        export GIT_CONFIG_GLOBAL="$(mktemp)"
+                        trap 'rm -f "$GIT_CONFIG_GLOBAL"' EXIT
                         git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
                         npm ci --legacy-peer-deps --cache /tmp/.npm-cache
                         npm run test:unit

--- a/jsapp/jest/unit.config.ts
+++ b/jsapp/jest/unit.config.ts
@@ -1,6 +1,21 @@
 import type { Config } from 'jest'
 import { defaults } from 'jest-config'
 
+// OC fork: @openclinica/logic-builder is a private optionalDependency. Map the
+// bare specifier to the committed CI stub only when the real package isn't
+// installed (public CI); otherwise let jest resolve the real one. Its
+// `/style.css` import is already covered by the CSS mapper below.
+const logicBuilderMap = ((): Record<string, string> => {
+  try {
+    require.resolve('@openclinica/logic-builder')
+    return {}
+  } catch {
+    return {
+      '^@openclinica/logic-builder$': '<rootDir>/../js/openclinica/logic-builder-stub/index.tsx',
+    }
+  }
+})()
+
 // Config to run ☕ unit tests using the Jest runner
 //
 // To run the unit tests: 🏃
@@ -22,6 +37,7 @@ const config: Config = {
   moduleNameMapper: {
     // ℹ️ same aliases as in webpack.common.js (module.resolve.alias)
     '^#/(.*)$': '<rootDir>/../js/$1', // 📁 'js/*'
+    ...logicBuilderMap, // 🧩 CI stub for the private @openclinica/logic-builder when absent
     // 🎨 mock all CSS modules imported (styles.root = 'root')
     '\\.(css|scss)$': 'identity-obj-proxy',
   },

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -327,7 +327,11 @@ export default function EditableForm(props: EditableFormProps) {
       launchAppForSurveyContent()
     }
 
-    stores.surveyState.listen(onSurveyStateChanged)
+    // OC fork (round-5 #6): capture the unsubscribe so this instance stops
+    // hearing surveyState changes on unmount. Without it, every
+    // mounted-then-unmounted EditableForm left a live listener, and the
+    // `setState` below re-entered all of them.
+    const unlistenSurveyState = stores.surveyState.listen(onSurveyStateChanged)
 
     return () => {
       // OC fork: drop the cached form style on unmount.
@@ -338,6 +342,9 @@ export default function EditableForm(props: EditableFormProps) {
       // settings-drawer close path, so release every Generate-button React
       // root and drop any dialog request still pointing at the old form.
       unmountAll()
+      if (typeof unlistenSurveyState === 'function') {
+        unlistenSurveyState()
+      }
       stores.surveyState.setState({ [GENERATE_REQUEST_KEY]: null })
     }
   }, [])
@@ -387,73 +394,70 @@ export default function EditableForm(props: EditableFormProps) {
   // Generate buttons (see openclinica/generateButtonBridge.tsx).
   //
   // Focus-on-close is owned here, not by the package: the dialog is embedded
-  // and the builder is inert while it's open, so the package's captured-opener
-  // restore doesn't reliably land in this host (verified live). Apply focuses
-  // the panel's expression field (below); a *dismiss* (Cancel / × / Escape)
-  // returns focus to the panel's Generate button. This ref tells the two apart
-  // — the package calls onApply then onClose, so an Apply sets it before the
-  // close fires.
+  // and the builder is inert while it's open, so the package no longer attempts
+  // its own focus restore (round-5 B/D). The package calls onApply then onClose,
+  // so `closeGenerateDialog` (bound to onClose) is the SINGLE close + focus
+  // site — `applyGeneratedExpression` (onApply) only writes and flags the
+  // outcome, never closes, which is what previously double-fired the close and
+  // defeated Apply-focus (round-5 #1). This ref tells the close which way to
+  // send focus: a successful Apply → the panel's expression field; a dismiss,
+  // rejection, or error → the panel's Generate button.
   const closingViaApplyRef = useRef(false)
   function closeGenerateDialog() {
     const wasApply = closingViaApplyRef.current
     closingViaApplyRef.current = false
-    const attribute = state[GENERATE_REQUEST_KEY]?.attribute
+    const request = state[GENERATE_REQUEST_KEY]
+    const attribute = request?.attribute
+    // Scope the focus lookup to the row's own settings drawer so a second open
+    // drawer — or a group + child row sharing a class — can't be hit (round-5 #2).
+    const root: ParentNode = request?.settingsRoot instanceof HTMLElement ? request.settingsRoot : document
     stores.surveyState.setState({ [GENERATE_REQUEST_KEY]: null })
-    if (!wasApply && attribute) {
-      // Dismiss (P1.1 AC6): return focus to the Generate button after the
-      // dialog unmounts and the builder's inert clears (same deferral the
-      // Apply-focus path uses).
-      window.setTimeout(() => focusGenerateButton(attribute), 0)
+    if (!attribute) {
+      return
     }
+    // Defer past the dialog unmount + inert clear (focusing an inert element is
+    // a silent no-op). One timer, one target — no competing focus writes.
+    window.setTimeout(() => {
+      if (wasApply) {
+        focusPanelInput(attribute, root) // P1.3 AC4
+      } else {
+        focusGenerateButton(attribute, root) // P1.1 AC6
+      }
+    }, 0)
   }
 
   function applyGeneratedExpression(expression: string) {
+    // Never closes the dialog itself — the package's onClose (closeGenerateDialog)
+    // is the single close site (round-5 #1). This only writes and flags the
+    // focus target for that close.
     const request = state[GENERATE_REQUEST_KEY]
     if (!request?.row || !request?.attribute) {
-      closeGenerateDialog()
       return
     }
     // The write path lives in openclinica/applyExpression.ts (unit-tested);
-    // this handler only maps the outcome onto user feedback + dialog state.
+    // this handler only maps the outcome onto user feedback + focus intent.
     const outcome = applyExpressionToRow(request.row, request.attribute, expression)
-    if (outcome.status === 'error') {
-      // Missing RowDetail, detached row, or a throw mid-write: the dialog
-      // closes on Apply regardless, so surface an error instead of letting a
-      // silent no-op look like a saved value (PR#273 rounds 2–3).
-      console.error(
-        'Logic Builder: could not apply generated expression —',
-        outcome.reason,
-        request.attribute,
-      )
-      alertify.error(t('Could not apply the generated expression. Please try again.'))
-      closeGenerateDialog()
+    if (outcome.status === 'applied') {
+      // Send focus to the panel's expression field on close (not the Generate
+      // button).
+      closingViaApplyRef.current = true
       return
     }
-    if (outcome.storedMismatch) {
-      // The skip-logic facade re-serialized the expression and dropped what it
-      // couldn't resolve (PR#273 round-3): make the loss visible before it
-      // leaves Draft rather than silently saving a reduced expression.
-      console.warn(
-        'Logic Builder: this panel could not represent the applied expression as written',
-        outcome.storedMismatch,
-      )
+    if (outcome.status === 'rejected') {
+      // The skip-logic facade could not represent every clause and dropped the
+      // references it can't resolve; applyExpressionToRow already reverted the
+      // write, so nothing was persisted (round-5 #5). Report which references
+      // were unresolved and leave focus to return to the Generate button.
+      const names = outcome.unresolved.map((ref) => ref.replace(/^\$\{|\}$/g, '')).join(', ')
+      console.warn('Logic Builder: refused a lossy apply and reverted; unresolved references', outcome.unresolved, request.attribute)
       alertify.error(
-        t(
-          'Part of the applied expression could not be represented in this panel (it may reference a question that does not exist on this form) and will not be saved as written. Review the panel before saving.',
-        ),
+        t('The generated expression references ##refs## which do not exist on this form, so it was not applied. Nothing was changed.').replace('##refs##', names),
       )
+      return
     }
-    const attribute = request.attribute
-    // Mark this close as an Apply so closeGenerateDialog focuses the expression
-    // field (below), not the Generate button.
-    closingViaApplyRef.current = true
-    closeGenerateDialog()
-    // P1.3 AC4: Apply moves focus to the panel's expression field. Wait for
-    // React to commit the dialog unmount first — the builder stays inert until
-    // then, and focusing an inert element is a silent no-op.
-    window.setTimeout(() => {
-      focusPanelInput(attribute)
-    }, 0)
+    // status === 'error': missing RowDetail, detached row, or a throw mid-write.
+    console.error('Logic Builder: could not apply generated expression —', outcome.reason, request.attribute)
+    alertify.error(t('Could not apply the generated expression. Please try again.'))
   }
 
   // Defensive (PR#273 #2): if a generate request ever carries an attribute that

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -75,6 +75,10 @@ import { AiGeneratorDialog, type FormField, type FormFieldContext } from '@openc
 import { logicBuilderStubClient } from '#/openclinica/logicBuilderStubClient'
 import { GENERATE_REQUEST_KEY, columnToTab } from '#/openclinica/logicBuilderTabs'
 
+// OC fork (P1.3): only Calculation and Default block newlines on manual entry,
+// so an applied AI result is normalized only for those two (PR#273 #3).
+const NEWLINE_STRIPPING_ATTRIBUTES = new Set(['calculation', 'default'])
+
 const ErrorMessage = makeBem(null, 'error-message')
 const ErrorMessage__strong = makeBem(null, 'error-message__header', 'strong')
 bem.CascadePopup = makeBem(null, 'cascade-popup')
@@ -192,7 +196,8 @@ function buildFieldContext(row: any): FormFieldContext {
         let name = ''
         try {
           name = r.getValue('name') || ''
-        } catch {
+        } catch (e) {
+          console.warn('Logic Builder: failed to read a field name for AI context', e)
           name = ''
         }
         if (!name) {
@@ -201,14 +206,16 @@ function buildFieldContext(row: any): FormFieldContext {
         let type = ''
         try {
           type = String(r.getValue('type') || '')
-        } catch {
+        } catch (e) {
+          console.warn('Logic Builder: failed to read a field type for AI context', e)
           type = ''
         }
         let label = ''
         try {
           const rawLabel = r.getValue('label')
           label = Array.isArray(rawLabel) ? String(rawLabel[0] ?? '') : String(rawLabel ?? '')
-        } catch {
+        } catch (e) {
+          console.warn('Logic Builder: failed to read a field label for AI context', e)
           label = ''
         }
         fields.push({ name, type, label })
@@ -216,7 +223,8 @@ function buildFieldContext(row: any): FormFieldContext {
       { includeGroups: false },
     )
     return { fields }
-  } catch {
+  } catch (e) {
+    console.warn('Logic Builder: failed to build field context; using empty list', e)
     return { fields: [] }
   }
 }
@@ -251,6 +259,11 @@ export default function EditableForm(props: EditableFormProps) {
   })
 
   const formWrapRef = useRef<HTMLDivElement>(null)
+  // OC fork (P1.3): ref on the whole builder so the AI dialog can make it inert
+  // (aside + header + form content), keeping Save / Preview / Manage Languages
+  // unclickable while it is open (PR#273 #10). The dialog portals to <body>, so
+  // it itself stays interactive.
+  const formBuilderWrapRef = useRef<HTMLDivElement>(null)
   const cascadeRef = useRef<HTMLTextAreaElement>(null)
 
   const onSurveyChangeDebounced = debounce(onSurveyChange, 200)
@@ -375,20 +388,34 @@ export default function EditableForm(props: EditableFormProps) {
 
   function applyGeneratedExpression(expression: string) {
     const request = state[GENERATE_REQUEST_KEY]
-    if (request?.row && request?.attribute) {
-      try {
-        // Match the panel inputs, which strip newlines (calculation/default do
-        // `replace(/\n/g, '')` and block Enter). XLSForm expressions are
-        // single-line, so keep the model consistent with what the UI allows.
-        const normalized = expression.replace(/\r?\n/g, '')
-        // CRITICAL: write via the RowDetail wrapper, never row.set('<col>', ...).
-        request.row.get(request.attribute)?.set?.('value', normalized)
-        // `relevant`/`constraint` are not in the auto-`change` whitelist, so
-        // trigger it explicitly (idempotent for every attribute) to enable Save.
-        request.row.getSurvey?.()?.trigger?.('change')
-      } catch (e) {
-        console.error('Logic Builder: failed to apply generated expression', e)
-      }
+    const detail =
+      request?.row && request?.attribute ? request.row.get(request.attribute) : null
+    if (!request?.attribute || !detail?.set) {
+      // The RowDetail we meant to write is gone (row removed, stale reference,
+      // or a mapping miss). The dialog closes on Apply regardless, so surface an
+      // error instead of letting a silent no-op look like a saved value (PR#273 #1).
+      console.error(
+        'Logic Builder: could not apply generated expression — no RowDetail for',
+        request?.attribute,
+      )
+      alertify.error(t('Could not apply the generated expression. Please try again.'))
+      closeGenerateDialog()
+      return
+    }
+    try {
+      // Only Calculation/Default block newlines on manual entry; Constraint and
+      // Relevant keep them, so normalize only where manual input already does.
+      const value = NEWLINE_STRIPPING_ATTRIBUTES.has(request.attribute)
+        ? expression.replace(/\r?\n/g, '')
+        : expression
+      // CRITICAL: write via the RowDetail wrapper, never row.set('<col>', ...).
+      detail.set('value', value)
+      // `relevant`/`constraint` are not in the auto-`change` whitelist, so
+      // trigger it explicitly (idempotent for every attribute) to enable Save.
+      request.row.getSurvey?.()?.trigger?.('change')
+    } catch (e) {
+      console.error('Logic Builder: failed to apply generated expression', e)
+      alertify.error(t('Could not apply the generated expression. Please try again.'))
     }
     closeGenerateDialog()
   }
@@ -405,13 +432,15 @@ export default function EditableForm(props: EditableFormProps) {
     let currentExpression = ''
     try {
       currentExpression = request.row.get(request.attribute)?.get?.('value') || ''
-    } catch {
+    } catch (e) {
+      console.warn('Logic Builder: failed to read current expression for the dialog', e)
       currentExpression = ''
     }
     let itemName = ''
     try {
       itemName = request.row.getValue?.('name') || request.row.get?.('name')?.get?.('value') || ''
-    } catch {
+    } catch (e) {
+      console.warn('Logic Builder: failed to read item name for the dialog', e)
       itemName = ''
     }
     return (
@@ -424,7 +453,7 @@ export default function EditableForm(props: EditableFormProps) {
           currentExpression,
         }}
         client={logicBuilderStubClient}
-        inertRoot={formWrapRef.current}
+        inertRoot={formBuilderWrapRef.current}
         onApply={applyGeneratedExpression}
         onClose={closeGenerateDialog}
       />
@@ -1607,7 +1636,7 @@ export default function EditableForm(props: EditableFormProps) {
           */
           state.preventNavigatingOut && <Prompt />
         }
-        <div className='form-builder-wrapper'>
+        <div className='form-builder-wrapper' ref={formBuilderWrapRef}>
           {renderAside()}
 
           <bem.FormBuilder>

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -399,13 +399,15 @@ export default function EditableForm(props: EditableFormProps) {
   //
   // Focus-on-close is owned here, not by the package: the dialog is embedded
   // and the builder is inert while it's open, so the package no longer attempts
-  // its own focus restore (round-5 B/D). The package calls onApply then onClose,
-  // so `closeGenerateDialog` (bound to onClose) is the SINGLE close + focus
-  // site — `applyGeneratedExpression` (onApply) only writes and flags the
-  // outcome, never closes, which is what previously double-fired the close and
-  // defeated Apply-focus (round-5 #1). This ref tells the close which way to
-  // send focus: a successful Apply → the panel's expression field; a dismiss,
-  // rejection, or error → the panel's Generate button.
+  // its own focus restore (round-5 B/D). The package calls onApply and closes
+  // (onClose) ONLY when onApply reports the write persisted (round-6): a
+  // successful apply returns true → the package dismisses and
+  // `closeGenerateDialog` runs; a rejected/failed apply returns false → the
+  // package keeps the dialog open so the user's prompt + proposal survive, and
+  // `closeGenerateDialog` never runs. `closeGenerateDialog` (bound to onClose)
+  // remains the SINGLE close + focus site (round-5 #1). This ref tells that
+  // close which way to send focus: a successful Apply → the panel's expression
+  // field; a dismiss (×/Escape) → the panel's Generate button.
   const closingViaApplyRef = useRef(false)
   function closeGenerateDialog() {
     const wasApply = closingViaApplyRef.current
@@ -430,38 +432,44 @@ export default function EditableForm(props: EditableFormProps) {
     }, 0)
   }
 
-  function applyGeneratedExpression(expression: string) {
-    // Never closes the dialog itself — the package's onClose (closeGenerateDialog)
-    // is the single close site (round-5 #1). This only writes and flags the
-    // focus target for that close.
+  // Bound to the package's onApply. Returns whether the expression was actually
+  // persisted: true → the package dismisses the dialog (closeGenerateDialog runs
+  // and focuses the panel input); false → the package keeps the dialog open so a
+  // rejected/failed apply doesn't discard the user's prompt + proposal (round-6).
+  // Never closes the dialog itself — closeGenerateDialog (onClose) is the single
+  // close site (round-5 #1).
+  function applyGeneratedExpression(expression: string): boolean {
     const request = state[GENERATE_REQUEST_KEY]
     if (!request?.row || !request?.attribute) {
-      return
+      return false
     }
     // The write path lives in openclinica/applyExpression.ts (unit-tested);
     // this handler only maps the outcome onto user feedback + focus intent.
     const outcome = applyExpressionToRow(request.row, request.attribute, expression)
     if (outcome.status === 'applied') {
-      // Send focus to the panel's expression field on close (not the Generate
-      // button).
+      // Persisted. Flag the focus target for the package-driven close (the
+      // panel's expression field, not the Generate button) and report success.
       closingViaApplyRef.current = true
-      return
+      return true
     }
     if (outcome.status === 'rejected') {
       // The skip-logic facade could not represent every clause and dropped the
       // references it can't resolve; applyExpressionToRow already reverted the
       // write, so nothing was persisted (round-5 #5). Report which references
-      // were unresolved and leave focus to return to the Generate button.
+      // were unresolved; return false so the dialog stays open for the user to
+      // adjust the prompt and retry without retyping (round-6).
       const names = outcome.unresolved.map((ref) => ref.replace(/^\$\{|\}$/g, '')).join(', ')
       console.warn('Logic Builder: refused a lossy apply and reverted; unresolved references', outcome.unresolved, request.attribute)
       alertify.error(
         t('The generated expression references ##refs## which do not exist on this form, so it was not applied. Nothing was changed.').replace('##refs##', names),
       )
-      return
+      return false
     }
     // status === 'error': missing RowDetail, detached row, or a throw mid-write.
+    // Keep the dialog open (return false) so the proposal isn't lost.
     console.error('Logic Builder: could not apply generated expression —', outcome.reason, request.attribute)
     alertify.error(t('Could not apply the generated expression. Please try again.'))
+    return false
   }
 
   // Defensive (PR#273 #2): if a generate request ever carries an attribute that

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -70,6 +70,10 @@ import SurveyScope from '../models/surveyScope'
 import { type SurveyStateStoreData, stores } from '../stores'
 import { escapeHtml, recordKeys } from '../utils'
 import AssetNavigator from './AssetNavigator'
+// OC fork (P1.3): AI Generator dialog + Logic Builder wiring.
+import { AiGeneratorDialog, type FormFieldContext } from '@openclinica/logic-builder'
+import { logicBuilderStubClient } from '#/openclinica/logicBuilderStubClient'
+import { GENERATE_REQUEST_KEY, columnToTab } from '#/openclinica/logicBuilderTabs'
 
 const ErrorMessage = makeBem(null, 'error-message')
 const ErrorMessage__strong = makeBem(null, 'error-message__header', 'strong')
@@ -168,6 +172,52 @@ interface EditableFormState extends SurveyStateStoreData {
   surveyAppRendered: boolean
   surveyLoadError: string | undefined
   surveySaveFail: boolean
+}
+
+/**
+ * OC fork (P1.3): best-effort read of the survey's fields to give the AI
+ * Generator dialog some context. The STUB client ignores it, so any failure
+ * here is non-fatal — we fall back to an empty field list.
+ */
+function buildFieldContext(row: any): FormFieldContext {
+  try {
+    const survey = row?.getSurvey?.()
+    if (!survey?.forEachRow) {
+      return { fields: [] }
+    }
+    const fields: FormFieldContext['fields'] = []
+    survey.forEachRow(
+      (r: any) => {
+        let name = ''
+        try {
+          name = r.getValue('name') || ''
+        } catch {
+          name = ''
+        }
+        if (!name) {
+          return
+        }
+        let type = ''
+        try {
+          type = String(r.getValue('type') || '')
+        } catch {
+          type = ''
+        }
+        let label = ''
+        try {
+          const rawLabel = r.getValue('label')
+          label = Array.isArray(rawLabel) ? String(rawLabel[0] ?? '') : String(rawLabel ?? '')
+        } catch {
+          label = ''
+        }
+        fields.push({ name, type, label })
+      },
+      { includeGroups: false },
+    )
+    return { fields }
+  } catch {
+    return { fields: [] }
+  }
 }
 
 /**
@@ -313,6 +363,71 @@ export default function EditableForm(props: EditableFormProps) {
       ...currentState,
       ...storeState,
     }))
+  }
+
+  // OC fork (P1.3): AI Generator dialog open/close/apply, driven by the
+  // `generateRequest` pushed onto `stores.surveyState` by the Backbone-side
+  // Generate buttons (see openclinica/generateButtonBridge.tsx).
+  function closeGenerateDialog() {
+    stores.surveyState.setState({ [GENERATE_REQUEST_KEY]: null })
+  }
+
+  function applyGeneratedExpression(expression: string) {
+    const request = state[GENERATE_REQUEST_KEY]
+    if (request?.row && request?.attribute) {
+      try {
+        // Match the panel inputs, which strip newlines (calculation/default do
+        // `replace(/\n/g, '')` and block Enter). XLSForm expressions are
+        // single-line, so keep the model consistent with what the UI allows.
+        const normalized = expression.replace(/\r?\n/g, '')
+        // CRITICAL: write via the RowDetail wrapper, never row.set('<col>', ...).
+        request.row.get(request.attribute)?.set?.('value', normalized)
+        // `relevant`/`constraint` are not in the auto-`change` whitelist, so
+        // trigger it explicitly (idempotent for every attribute) to enable Save.
+        request.row.getSurvey?.()?.trigger?.('change')
+      } catch (e) {
+        console.error('Logic Builder: failed to apply generated expression', e)
+      }
+    }
+    closeGenerateDialog()
+  }
+
+  function renderAiGeneratorDialog() {
+    const request = state[GENERATE_REQUEST_KEY]
+    if (!request?.row || !request?.attribute) {
+      return null
+    }
+    const tab = columnToTab(request.attribute)
+    if (!tab) {
+      return null
+    }
+    let currentExpression = ''
+    try {
+      currentExpression = request.row.get(request.attribute)?.get?.('value') || ''
+    } catch {
+      currentExpression = ''
+    }
+    let itemName = ''
+    try {
+      itemName = request.row.getValue?.('name') || request.row.get?.('name')?.get?.('value') || ''
+    } catch {
+      itemName = ''
+    }
+    return (
+      <AiGeneratorDialog
+        open
+        scope={{
+          itemName,
+          attribute: tab,
+          fields: buildFieldContext(request.row),
+          currentExpression,
+        }}
+        client={logicBuilderStubClient}
+        inertRoot={formWrapRef.current}
+        onApply={applyGeneratedExpression}
+        onClose={closeGenerateDialog}
+      />
+    )
   }
 
   function onStyleChange(newStyle: null | FormStyleDefinition) {
@@ -1531,6 +1646,9 @@ export default function EditableForm(props: EditableFormProps) {
               <Modal.Body>{renderCascadePopup()}</Modal.Body>
             </Modal>
           )}
+
+          {/* OC fork (P1.3): AI Generator dialog (portals to document.body itself). */}
+          {renderAiGeneratorDialog()}
         </div>
       </>
     </DocumentTitle>

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -74,7 +74,7 @@ import AssetNavigator from './AssetNavigator'
 import { AiGeneratorDialog, type FormField, type FormFieldContext } from '@openclinica/logic-builder'
 import { logicBuilderStubClient } from '#/openclinica/logicBuilderStubClient'
 import { GENERATE_REQUEST_KEY, columnToTab } from '#/openclinica/logicBuilderTabs'
-import { applyExpressionToRow, focusPanelInput } from '#/openclinica/applyExpression'
+import { applyExpressionToRow, focusPanelInput, focusGenerateButton } from '#/openclinica/applyExpression'
 import { unmountAll } from '#/openclinica/generateButtonBridge'
 
 const ErrorMessage = makeBem(null, 'error-message')
@@ -385,8 +385,26 @@ export default function EditableForm(props: EditableFormProps) {
   // OC fork (P1.1): AI Generator dialog open/close/apply, driven by the
   // `generateRequest` pushed onto `stores.surveyState` by the Backbone-side
   // Generate buttons (see openclinica/generateButtonBridge.tsx).
+  //
+  // Focus-on-close is owned here, not by the package: the dialog is embedded
+  // and the builder is inert while it's open, so the package's captured-opener
+  // restore doesn't reliably land in this host (verified live). Apply focuses
+  // the panel's expression field (below); a *dismiss* (Cancel / × / Escape)
+  // returns focus to the panel's Generate button. This ref tells the two apart
+  // — the package calls onApply then onClose, so an Apply sets it before the
+  // close fires.
+  const closingViaApplyRef = useRef(false)
   function closeGenerateDialog() {
+    const wasApply = closingViaApplyRef.current
+    closingViaApplyRef.current = false
+    const attribute = state[GENERATE_REQUEST_KEY]?.attribute
     stores.surveyState.setState({ [GENERATE_REQUEST_KEY]: null })
+    if (!wasApply && attribute) {
+      // Dismiss (P1.1 AC6): return focus to the Generate button after the
+      // dialog unmounts and the builder's inert clears (same deferral the
+      // Apply-focus path uses).
+      window.setTimeout(() => focusGenerateButton(attribute), 0)
+    }
   }
 
   function applyGeneratedExpression(expression: string) {
@@ -426,6 +444,9 @@ export default function EditableForm(props: EditableFormProps) {
       )
     }
     const attribute = request.attribute
+    // Mark this close as an Apply so closeGenerateDialog focuses the expression
+    // field (below), not the Generate button.
+    closingViaApplyRef.current = true
     closeGenerateDialog()
     // P1.3 AC4: Apply moves focus to the panel's expression field. Wait for
     // React to commit the dialog unmount first — the builder stays inert until

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Text } from '@mantine/core'
+// OC fork (P1.1): AI Generator dialog + Logic Builder wiring.
+import { AiGeneratorDialog, type FormField, type FormFieldContext } from '@openclinica/logic-builder'
 import alertify from 'alertifyjs'
 import cx from 'classnames'
 import clonedeep from 'lodash.clonedeep'
@@ -52,6 +54,10 @@ import {
   update_states,
 } from '#/constants'
 import envStore from '#/envStore'
+import { applyExpressionToRow, focusGenerateButton, focusPanelInput } from '#/openclinica/applyExpression'
+import { unmountAll } from '#/openclinica/generateButtonBridge'
+import { logicBuilderStubClient } from '#/openclinica/logicBuilderStubClient'
+import { GENERATE_REQUEST_KEY, columnToTab } from '#/openclinica/logicBuilderTabs'
 import pageState from '#/pageState.store'
 import type { RouterProp } from '#/router/legacy'
 import { ROUTES } from '#/router/routerConstants'
@@ -73,12 +79,6 @@ import SurveyScope from '../models/surveyScope'
 import { type SurveyStateStoreData, stores } from '../stores'
 import { escapeHtml, recordKeys } from '../utils'
 import AssetNavigator from './AssetNavigator'
-// OC fork (P1.1): AI Generator dialog + Logic Builder wiring.
-import { AiGeneratorDialog, type FormField, type FormFieldContext } from '@openclinica/logic-builder'
-import { logicBuilderStubClient } from '#/openclinica/logicBuilderStubClient'
-import { GENERATE_REQUEST_KEY, columnToTab } from '#/openclinica/logicBuilderTabs'
-import { applyExpressionToRow, focusPanelInput, focusGenerateButton } from '#/openclinica/applyExpression'
-import { unmountAll } from '#/openclinica/generateButtonBridge'
 
 const ErrorMessage = makeBem(null, 'error-message')
 const ErrorMessage__strong = makeBem(null, 'error-message__header', 'strong')
@@ -459,9 +459,15 @@ export default function EditableForm(props: EditableFormProps) {
       // were unresolved; return false so the dialog stays open for the user to
       // adjust the prompt and retry without retyping (round-6).
       const names = outcome.unresolved.map((ref) => ref.replace(/^\$\{|\}$/g, '')).join(', ')
-      console.warn('Logic Builder: refused a lossy apply and reverted; unresolved references', outcome.unresolved, request.attribute)
+      console.warn(
+        'Logic Builder: refused a lossy apply and reverted; unresolved references',
+        outcome.unresolved,
+        request.attribute,
+      )
       alertify.error(
-        t('The generated expression references ##refs## which do not exist on this form, so it was not applied. Nothing was changed.').replace('##refs##', names),
+        t(
+          'The generated expression references ##refs## which do not exist on this form, so it was not applied. Nothing was changed.',
+        ).replace('##refs##', names),
       )
       return false
     }

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -74,10 +74,8 @@ import AssetNavigator from './AssetNavigator'
 import { AiGeneratorDialog, type FormField, type FormFieldContext } from '@openclinica/logic-builder'
 import { logicBuilderStubClient } from '#/openclinica/logicBuilderStubClient'
 import { GENERATE_REQUEST_KEY, columnToTab } from '#/openclinica/logicBuilderTabs'
-
-// OC fork (P1.1): only Calculation and Default block newlines on manual entry,
-// so an applied AI result is normalized only for those two (PR#273 #3).
-const NEWLINE_STRIPPING_ATTRIBUTES = new Set(['calculation', 'default'])
+import { applyExpressionToRow, focusPanelInput } from '#/openclinica/applyExpression'
+import { unmountAll } from '#/openclinica/generateButtonBridge'
 
 const ErrorMessage = makeBem(null, 'error-message')
 const ErrorMessage__strong = makeBem(null, 'error-message__header', 'strong')
@@ -336,6 +334,11 @@ export default function EditableForm(props: EditableFormProps) {
       sessionStorage.removeItem(FORM_STYLE_CACHE_NAME)
       unpreventClosingTab()
       cleanupAppForSurveyContent()
+      // OC fork (P1.1, PR#273 round-3): leaving the Form Designer bypasses the
+      // settings-drawer close path, so release every Generate-button React
+      // root and drop any dialog request still pointing at the old form.
+      unmountAll()
+      stores.surveyState.setState({ [GENERATE_REQUEST_KEY]: null })
     }
   }, [])
 
@@ -388,36 +391,48 @@ export default function EditableForm(props: EditableFormProps) {
 
   function applyGeneratedExpression(expression: string) {
     const request = state[GENERATE_REQUEST_KEY]
-    const detail =
-      request?.row && request?.attribute ? request.row.get(request.attribute) : null
-    if (!request?.attribute || !detail?.set) {
-      // The RowDetail we meant to write is gone (row removed, stale reference,
-      // or a mapping miss). The dialog closes on Apply regardless, so surface an
-      // error instead of letting a silent no-op look like a saved value (PR#273 #1).
+    if (!request?.row || !request?.attribute) {
+      closeGenerateDialog()
+      return
+    }
+    // The write path lives in openclinica/applyExpression.ts (unit-tested);
+    // this handler only maps the outcome onto user feedback + dialog state.
+    const outcome = applyExpressionToRow(request.row, request.attribute, expression)
+    if (outcome.status === 'error') {
+      // Missing RowDetail, detached row, or a throw mid-write: the dialog
+      // closes on Apply regardless, so surface an error instead of letting a
+      // silent no-op look like a saved value (PR#273 rounds 2–3).
       console.error(
-        'Logic Builder: could not apply generated expression — no RowDetail for',
-        request?.attribute,
+        'Logic Builder: could not apply generated expression —',
+        outcome.reason,
+        request.attribute,
       )
       alertify.error(t('Could not apply the generated expression. Please try again.'))
       closeGenerateDialog()
       return
     }
-    try {
-      // Only Calculation/Default block newlines on manual entry; Constraint and
-      // Relevant keep them, so normalize only where manual input already does.
-      const value = NEWLINE_STRIPPING_ATTRIBUTES.has(request.attribute)
-        ? expression.replace(/\r?\n/g, '')
-        : expression
-      // CRITICAL: write via the RowDetail wrapper, never row.set('<col>', ...).
-      detail.set('value', value)
-      // `relevant`/`constraint` are not in the auto-`change` whitelist, so
-      // trigger it explicitly (idempotent for every attribute) to enable Save.
-      request.row.getSurvey?.()?.trigger?.('change')
-    } catch (e) {
-      console.error('Logic Builder: failed to apply generated expression', e)
-      alertify.error(t('Could not apply the generated expression. Please try again.'))
+    if (outcome.storedMismatch) {
+      // The skip-logic facade re-serialized the expression and dropped what it
+      // couldn't resolve (PR#273 round-3): make the loss visible before it
+      // leaves Draft rather than silently saving a reduced expression.
+      console.warn(
+        'Logic Builder: this panel could not represent the applied expression as written',
+        outcome.storedMismatch,
+      )
+      alertify.error(
+        t(
+          'Part of the applied expression could not be represented in this panel (it may reference a question that does not exist on this form) and will not be saved as written. Review the panel before saving.',
+        ),
+      )
     }
+    const attribute = request.attribute
     closeGenerateDialog()
+    // P1.3 AC4: Apply moves focus to the panel's expression field. Wait for
+    // React to commit the dialog unmount first — the builder stays inert until
+    // then, and focusing an inert element is a silent no-op.
+    window.setTimeout(() => {
+      focusPanelInput(attribute)
+    }, 0)
   }
 
   // Defensive (PR#273 #2): if a generate request ever carries an attribute that

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -70,12 +70,12 @@ import SurveyScope from '../models/surveyScope'
 import { type SurveyStateStoreData, stores } from '../stores'
 import { escapeHtml, recordKeys } from '../utils'
 import AssetNavigator from './AssetNavigator'
-// OC fork (P1.3): AI Generator dialog + Logic Builder wiring.
+// OC fork (P1.1): AI Generator dialog + Logic Builder wiring.
 import { AiGeneratorDialog, type FormField, type FormFieldContext } from '@openclinica/logic-builder'
 import { logicBuilderStubClient } from '#/openclinica/logicBuilderStubClient'
 import { GENERATE_REQUEST_KEY, columnToTab } from '#/openclinica/logicBuilderTabs'
 
-// OC fork (P1.3): only Calculation and Default block newlines on manual entry,
+// OC fork (P1.1): only Calculation and Default block newlines on manual entry,
 // so an applied AI result is normalized only for those two (PR#273 #3).
 const NEWLINE_STRIPPING_ATTRIBUTES = new Set(['calculation', 'default'])
 
@@ -179,7 +179,7 @@ interface EditableFormState extends SurveyStateStoreData {
 }
 
 /**
- * OC fork (P1.3): best-effort read of the survey's fields to give the AI
+ * OC fork (P1.1): best-effort read of the survey's fields to give the AI
  * Generator dialog some context. The STUB client ignores it, so any failure
  * here is non-fatal — we fall back to an empty field list.
  */
@@ -259,7 +259,7 @@ export default function EditableForm(props: EditableFormProps) {
   })
 
   const formWrapRef = useRef<HTMLDivElement>(null)
-  // OC fork (P1.3): ref on the whole builder so the AI dialog can make it inert
+  // OC fork (P1.1): ref on the whole builder so the AI dialog can make it inert
   // (aside + header + form content), keeping Save / Preview / Manage Languages
   // unclickable while it is open (PR#273 #10). The dialog portals to <body>, so
   // it itself stays interactive.
@@ -379,7 +379,7 @@ export default function EditableForm(props: EditableFormProps) {
     }))
   }
 
-  // OC fork (P1.3): AI Generator dialog open/close/apply, driven by the
+  // OC fork (P1.1): AI Generator dialog open/close/apply, driven by the
   // `generateRequest` pushed onto `stores.surveyState` by the Backbone-side
   // Generate buttons (see openclinica/generateButtonBridge.tsx).
   function closeGenerateDialog() {
@@ -420,6 +420,23 @@ export default function EditableForm(props: EditableFormProps) {
     closeGenerateDialog()
   }
 
+  // Defensive (PR#273 #2): if a generate request ever carries an attribute that
+  // maps to no logic tab, the dialog can't render for it — clear the dangling
+  // request (so a clicked Generate doesn't silently do nothing) and leave a
+  // trace. Done in an effect, not during render, to avoid setState-in-render.
+  // In practice unreachable: the Generate button is only mounted for mappable
+  // columns (generateButtonBridge.mountGenerateButton).
+  const generateRequest = state[GENERATE_REQUEST_KEY]
+  useEffect(() => {
+    if (generateRequest?.attribute && !columnToTab(generateRequest.attribute)) {
+      console.warn(
+        'Logic Builder: no logic tab maps to the generate-request attribute; clearing it',
+        generateRequest.attribute,
+      )
+      stores.surveyState.setState({ [GENERATE_REQUEST_KEY]: null })
+    }
+  }, [generateRequest])
+
   function renderAiGeneratorDialog() {
     const request = state[GENERATE_REQUEST_KEY]
     if (!request?.row || !request?.attribute) {
@@ -427,6 +444,8 @@ export default function EditableForm(props: EditableFormProps) {
     }
     const tab = columnToTab(request.attribute)
     if (!tab) {
+      // No dialog for an unmappable attribute; the effect above clears the
+      // dangling request + logs (PR#273 #2). Can't reset state during render.
       return null
     }
     let currentExpression = ''
@@ -1677,7 +1696,7 @@ export default function EditableForm(props: EditableFormProps) {
             </Modal>
           )}
 
-          {/* OC fork (P1.3): AI Generator dialog (portals to document.body itself). */}
+          {/* OC fork (P1.1): AI Generator dialog (portals to document.body itself). */}
           {renderAiGeneratorDialog()}
         </div>
       </>

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -71,7 +71,7 @@ import { type SurveyStateStoreData, stores } from '../stores'
 import { escapeHtml, recordKeys } from '../utils'
 import AssetNavigator from './AssetNavigator'
 // OC fork (P1.3): AI Generator dialog + Logic Builder wiring.
-import { AiGeneratorDialog, type FormFieldContext } from '@openclinica/logic-builder'
+import { AiGeneratorDialog, type FormField, type FormFieldContext } from '@openclinica/logic-builder'
 import { logicBuilderStubClient } from '#/openclinica/logicBuilderStubClient'
 import { GENERATE_REQUEST_KEY, columnToTab } from '#/openclinica/logicBuilderTabs'
 
@@ -185,7 +185,8 @@ function buildFieldContext(row: any): FormFieldContext {
     if (!survey?.forEachRow) {
       return { fields: [] }
     }
-    const fields: FormFieldContext['fields'] = []
+    // Mutable local we build up, then hand off as the readonly context field.
+    const fields: FormField[] = []
     survey.forEachRow(
       (r: any) => {
         let name = ''

--- a/jsapp/js/openclinica/applyExpression.tests.ts
+++ b/jsapp/js/openclinica/applyExpression.tests.ts
@@ -1,0 +1,136 @@
+import chai from 'chai'
+import { applyExpressionToRow, focusPanelInput } from './applyExpression'
+
+// Minimal Backbone-ish fakes: a row hands out a RowDetail via get(attribute)
+// and its survey via getSurvey(); the detail exposes set()/getValue().
+function makeRow(options: { detail?: any; survey?: any } = {}) {
+  const detail =
+    'detail' in options
+      ? options.detail
+      : { set: jest.fn(), getValue: jest.fn() }
+  const survey = 'survey' in options ? options.survey : { trigger: jest.fn() }
+  const row = {
+    get: jest.fn(() => detail),
+    getSurvey: jest.fn(() => survey),
+  }
+  return { row, detail, survey }
+}
+
+describe('applyExpressionToRow (P1.3)', () => {
+  let errorSpy: jest.SpyInstance
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    errorSpy.mockRestore()
+  })
+
+  it('reports missing-detail when the row has no RowDetail for the attribute', () => {
+    const { row } = makeRow({ detail: undefined })
+    const outcome = applyExpressionToRow(row, 'calculation', '1 + 1')
+    chai.expect(outcome).to.deep.equal({ status: 'error', reason: 'missing-detail' })
+  })
+
+  it('reports detached-row when getSurvey() returns null, without writing', () => {
+    const { row, detail } = makeRow({ survey: null })
+    const outcome = applyExpressionToRow(row, 'calculation', '1 + 1')
+    chai.expect(outcome).to.deep.equal({ status: 'error', reason: 'detached-row' })
+    chai.expect(detail.set.mock.calls.length).to.equal(0)
+  })
+
+  it('strips newlines for calculation, writes via the RowDetail, and triggers a survey change', () => {
+    const { row, detail, survey } = makeRow()
+    const outcome = applyExpressionToRow(row, 'calculation', '${A}\n + \r\n${B}')
+    chai.expect(outcome).to.deep.equal({ status: 'applied', storedMismatch: null })
+    chai.expect(detail.set.mock.calls).to.deep.equal([['value', '${A} + ${B}']])
+    chai.expect(survey.trigger.mock.calls).to.deep.equal([['change']])
+  })
+
+  it('keeps newlines for relevant (manual entry keeps them there too)', () => {
+    const { row, detail } = makeRow()
+    detail.getValue = jest.fn(() => '${A} = 1\nand ${B} = 2')
+    applyExpressionToRow(row, 'relevant', '${A} = 1\nand ${B} = 2')
+    chai.expect(detail.set.mock.calls[0][1]).to.equal('${A} = 1\nand ${B} = 2')
+  })
+
+  it('does not report a mismatch when the facade only reformats (whitespace / quote style)', () => {
+    const { row, detail } = makeRow()
+    detail.getValue = jest.fn(() => "${A}=1 and ${B}='x'")
+    const outcome = applyExpressionToRow(row, 'relevant', '${A} = 1 and ${B} = "x"')
+    chai.expect(outcome).to.deep.equal({ status: 'applied', storedMismatch: null })
+  })
+
+  it('reports a mismatch when the facade drops a clause it cannot resolve', () => {
+    const { row, detail } = makeRow()
+    detail.getValue = jest.fn(() => '${A} = 1')
+    const outcome = applyExpressionToRow(row, 'constraint', '${A} = 1 and ${NOPE} = 2')
+    chai.expect(outcome).to.deep.equal({
+      status: 'applied',
+      storedMismatch: { intended: '${A} = 1 and ${NOPE} = 2', stored: '${A} = 1' },
+    })
+  })
+
+  it('reports a mismatch when the facade serializes the whole expression away', () => {
+    const { row, detail } = makeRow()
+    detail.getValue = jest.fn(() => '')
+    const outcome = applyExpressionToRow(row, 'relevant', '${AGE} >= 18')
+    chai.expect(outcome.status).to.equal('applied')
+    chai.expect((outcome as any).storedMismatch).to.deep.equal({ intended: '${AGE} >= 18', stored: '' })
+  })
+
+  it('does not consult getValue for non-facade attributes', () => {
+    const { row, detail } = makeRow()
+    detail.getValue = jest.fn(() => 'something else entirely')
+    const outcome = applyExpressionToRow(row, 'calculation', '${A} + 1')
+    chai.expect(outcome).to.deep.equal({ status: 'applied', storedMismatch: null })
+    chai.expect(detail.getValue.mock.calls.length).to.equal(0)
+  })
+
+  it('reports write-failed when the RowDetail write throws', () => {
+    const { row } = makeRow({
+      detail: {
+        set: jest.fn(() => {
+          throw new Error('boom')
+        }),
+      },
+    })
+    const outcome = applyExpressionToRow(row, 'default', 'today()')
+    chai.expect(outcome).to.deep.equal({ status: 'error', reason: 'write-failed' })
+  })
+})
+
+describe('focusPanelInput (P1.3 AC4)', () => {
+  let warnSpy: jest.SpyInstance
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    document.body.innerHTML = ''
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+    document.body.innerHTML = ''
+  })
+
+  it('focuses the calculation input', () => {
+    document.body.innerHTML = '<textarea class="js-calculation-input"></textarea>'
+    const focused = focusPanelInput('calculation')
+    chai.expect(focused).to.equal(true)
+    chai.expect(document.activeElement?.className).to.equal('js-calculation-input')
+  })
+
+  it("focuses the relevant panel's first interactive control inside .skiplogic__main", () => {
+    document.body.innerHTML =
+      '<div class="js-card-settings-relevant-logic"><div class="skiplogic__main"><select class="target"></select></div></div>'
+    const focused = focusPanelInput('relevant')
+    chai.expect(focused).to.equal(true)
+    chai.expect(document.activeElement?.className).to.equal('target')
+  })
+
+  it('returns false for an unmapped attribute', () => {
+    chai.expect(focusPanelInput('bogus')).to.equal(false)
+  })
+
+  it('returns false and warns when the input is not in the DOM', () => {
+    chai.expect(focusPanelInput('calculation')).to.equal(false)
+    chai.expect(warnSpy.mock.calls.length).to.equal(1)
+  })
+})

--- a/jsapp/js/openclinica/applyExpression.tests.ts
+++ b/jsapp/js/openclinica/applyExpression.tests.ts
@@ -1,13 +1,10 @@
 import chai from 'chai'
-import { applyExpressionToRow, focusPanelInput, focusGenerateButton } from './applyExpression'
+import { applyExpressionToRow, focusGenerateButton, focusPanelInput } from './applyExpression'
 
 // Minimal Backbone-ish fakes: a row hands out a RowDetail via get(attribute)
 // and its survey via getSurvey(); the detail exposes set()/getValue().
 function makeRow(options: { detail?: any; survey?: any } = {}) {
-  const detail =
-    'detail' in options
-      ? options.detail
-      : { set: jest.fn(), getValue: jest.fn() }
+  const detail = 'detail' in options ? options.detail : { set: jest.fn(), getValue: jest.fn() }
   const survey = 'survey' in options ? options.survey : { trigger: jest.fn() }
   const row = {
     get: jest.fn(() => detail),
@@ -212,13 +209,12 @@ describe('focusGenerateButton (P1.1 AC6, dismiss)', () => {
   })
 
   it("focuses the panel's Generate button by its accessible name", () => {
-    document.body.innerHTML =
-      '<button aria-label="Generate Relevant Logic with AI">Generate</button>'
+    document.body.innerHTML = '<button aria-label="Generate Relevant Logic with AI">Generate</button>'
     const focused = focusGenerateButton('relevant')
     chai.expect(focused).to.equal(true)
-    chai.expect((document.activeElement as HTMLElement)?.getAttribute('aria-label')).to.equal(
-      'Generate Relevant Logic with AI',
-    )
+    chai
+      .expect((document.activeElement as HTMLElement)?.getAttribute('aria-label'))
+      .to.equal('Generate Relevant Logic with AI')
   })
 
   it('scopes to the requested attribute when several Generate buttons are present', () => {

--- a/jsapp/js/openclinica/applyExpression.tests.ts
+++ b/jsapp/js/openclinica/applyExpression.tests.ts
@@ -13,15 +13,24 @@ function makeRow(options: { detail?: any; survey?: any } = {}) {
   return { row, detail, survey }
 }
 
-// A facade-backed RowDetail whose getValue() returns a scripted sequence: the
-// pre-write serialization first (captured to restore on a lossy apply), then
-// the post-write serialization the drop-detection compares against.
-function makeFacadeRow(getValues: string[]) {
-  const getValue = jest.fn()
-  for (const v of getValues) getValue.mockReturnValueOnce(v)
-  getValue.mockReturnValue(getValues[getValues.length - 1] ?? '')
-  const detail = { set: jest.fn(), getValue }
-  return makeRow({ detail })
+// A facade-backed RowDetail modeled faithfully: `get('value')` returns the RAW
+// stored attribute (updated by set), while `getValue()` returns the facade's
+// re-serialization of the current raw value — the lossy round-trip that drops
+// clauses it can't resolve and reformats the rest (round-7). `serialize` is the
+// per-test facade behavior.
+function makeFacadeRow(opts: { raw?: string; serialize?: (raw: string) => string } = {}) {
+  const serialize = opts.serialize ?? ((raw: string) => raw)
+  let value = opts.raw ?? ''
+  const set = jest.fn((_key: string, v: string) => {
+    value = v
+  })
+  const detail = {
+    set,
+    get: jest.fn((key: string) => (key === 'value' ? value : undefined)),
+    getValue: jest.fn(() => serialize(value)),
+  }
+  const made = makeRow({ detail })
+  return { ...made, rawValue: () => value }
 }
 
 describe('applyExpressionToRow (P1.3)', () => {
@@ -65,7 +74,7 @@ describe('applyExpressionToRow (P1.3)', () => {
 
   it('keeps newlines for relevant (manual entry keeps them there too)', () => {
     // Stored form keeps both field refs → a clean apply, newlines preserved.
-    const { row, detail } = makeFacadeRow(['', '${A} = 1\nand ${B} = 2'])
+    const { row, detail } = makeFacadeRow()
     const outcome = applyExpressionToRow(row, 'relevant', '${A} = 1\nand ${B} = 2')
     chai.expect(outcome).to.deep.equal({ status: 'applied' })
     chai.expect(detail.set.mock.calls[0][1]).to.equal('${A} = 1\nand ${B} = 2')
@@ -74,14 +83,14 @@ describe('applyExpressionToRow (P1.3)', () => {
   it('does not flag a date() wrapper the serializer adds (round-5 #3 false positive)', () => {
     // DateOperator wraps a bare date literal in date('…') on serialize; the
     // field ref ${visit_date} survives, so this is a clean apply, not a drop.
-    const { row } = makeFacadeRow(['', "${visit_date} > date('2024-01-01')"])
+    const { row } = makeFacadeRow({ serialize: () => "${visit_date} > date('2024-01-01')" })
     const outcome = applyExpressionToRow(row, 'constraint', "${visit_date} > '2024-01-01'")
     chai.expect(outcome).to.deep.equal({ status: 'applied' })
   })
 
   it('does not flag quotes the serializer adds around an unquoted value (round-5 #3)', () => {
     // TextOperator wraps an unquoted value in quotes; ${subject_code} survives.
-    const { row } = makeFacadeRow(['', "${subject_code} = '123'"])
+    const { row } = makeFacadeRow({ serialize: () => "${subject_code} = '123'" })
     const outcome = applyExpressionToRow(row, 'constraint', '${subject_code} = 123')
     chai.expect(outcome).to.deep.equal({ status: 'applied' })
   })
@@ -91,7 +100,8 @@ describe('applyExpressionToRow (P1.3)', () => {
     // persist a silently-reduced expression, restore the previous value and
     // report a rejection.
     const previous = '${A} = 1'
-    const { row, detail } = makeFacadeRow([previous, '${A} = 1'])
+    const dropNope = (raw: string) => raw.replace(/ and \$\{NOPE\} = 2/, '')
+    const { row, detail } = makeFacadeRow({ raw: previous, serialize: dropNope })
     const outcome = applyExpressionToRow(row, 'constraint', '${A} = 1 and ${NOPE} = 2')
     chai.expect(outcome).to.deep.equal({
       status: 'rejected',
@@ -107,7 +117,7 @@ describe('applyExpressionToRow (P1.3)', () => {
   })
 
   it('refuses and reverts a total clause-drop', () => {
-    const { row, detail } = makeFacadeRow(['', ''])
+    const { row, detail } = makeFacadeRow({ serialize: (raw) => (raw.includes('${AGE}') ? '' : raw) })
     const outcome = applyExpressionToRow(row, 'relevant', '${AGE} >= 18')
     chai.expect(outcome.status).to.equal('rejected')
     chai.expect((outcome as any).unresolved).to.deep.equal(['${AGE}'])
@@ -115,6 +125,34 @@ describe('applyExpressionToRow (P1.3)', () => {
       ['value', '${AGE} >= 18'],
       ['value', ''],
     ])
+  })
+
+  it("reverts to the RAW stored text, never the facade's reserialization of it (round-7)", () => {
+    // The pre-existing raw value ALREADY holds a clause the facade drops on its
+    // own serialize pass (${typo_field} — deleted/renamed on the form). A
+    // rejected apply must restore exactly that raw text: capturing `previous`
+    // via getValue() would restore the facade's reduced round-trip and silently
+    // lose the clause while the toast claims nothing changed.
+    const raw = '${real_field} = 1 and ${typo_field} = 2'
+    const lossy = (s: string) => s.replace(/ and \$\{typo_field\} = 2/, '').replace(/\$\{AGE\} >= 18/, '')
+    const { row, detail, rawValue } = makeFacadeRow({ raw, serialize: lossy })
+    const outcome = applyExpressionToRow(row, 'relevant', '${AGE} >= 18')
+    chai.expect(outcome.status).to.equal('rejected')
+    // The revert wrote the raw original — clause intact — not the lossy form.
+    chai.expect(detail.set.mock.calls[detail.set.mock.calls.length - 1]).to.deep.equal(['value', raw])
+    chai.expect(rawValue()).to.equal(raw)
+  })
+
+  it('preserves the raw value when the rejected proposal is textually identical to it (round-7)', () => {
+    // Applying text identical to the current raw value: Backbone fires no
+    // change:value, the facade never rebuilds, and stored reads back the
+    // already-lossy serialization — a spurious "drop" report. Whatever the
+    // outcome, the raw attribute must come through byte-identical.
+    const raw = '${real_field} = 1 and ${typo_field} = 2'
+    const lossy = (s: string) => s.replace(/ and \$\{typo_field\} = 2/, '')
+    const { row, rawValue } = makeFacadeRow({ raw, serialize: lossy })
+    applyExpressionToRow(row, 'relevant', raw)
+    chai.expect(rawValue()).to.equal(raw)
   })
 
   it('does not consult getValue for non-facade attributes', () => {

--- a/jsapp/js/openclinica/applyExpression.tests.ts
+++ b/jsapp/js/openclinica/applyExpression.tests.ts
@@ -16,13 +16,27 @@ function makeRow(options: { detail?: any; survey?: any } = {}) {
   return { row, detail, survey }
 }
 
+// A facade-backed RowDetail whose getValue() returns a scripted sequence: the
+// pre-write serialization first (captured to restore on a lossy apply), then
+// the post-write serialization the drop-detection compares against.
+function makeFacadeRow(getValues: string[]) {
+  const getValue = jest.fn()
+  for (const v of getValues) getValue.mockReturnValueOnce(v)
+  getValue.mockReturnValue(getValues[getValues.length - 1] ?? '')
+  const detail = { set: jest.fn(), getValue }
+  return makeRow({ detail })
+}
+
 describe('applyExpressionToRow (P1.3)', () => {
   let errorSpy: jest.SpyInstance
+  let warnSpy: jest.SpyInstance
   beforeEach(() => {
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
   })
   afterEach(() => {
     errorSpy.mockRestore()
+    warnSpy.mockRestore()
   })
 
   it('reports missing-detail when the row has no RowDetail for the attribute', () => {
@@ -41,48 +55,76 @@ describe('applyExpressionToRow (P1.3)', () => {
   it('strips newlines for calculation, writes via the RowDetail, and triggers a survey change', () => {
     const { row, detail, survey } = makeRow()
     const outcome = applyExpressionToRow(row, 'calculation', '${A}\n + \r\n${B}')
-    chai.expect(outcome).to.deep.equal({ status: 'applied', storedMismatch: null })
+    chai.expect(outcome).to.deep.equal({ status: 'applied' })
     chai.expect(detail.set.mock.calls).to.deep.equal([['value', '${A} + ${B}']])
     chai.expect(survey.trigger.mock.calls).to.deep.equal([['change']])
   })
 
-  it('keeps newlines for relevant (manual entry keeps them there too)', () => {
+  it('strips newlines for required too — its panel input is single-line (round-5 #7)', () => {
     const { row, detail } = makeRow()
-    detail.getValue = jest.fn(() => '${A} = 1\nand ${B} = 2')
-    applyExpressionToRow(row, 'relevant', '${A} = 1\nand ${B} = 2')
+    applyExpressionToRow(row, 'required', '${A} = 1\nand ${B} = 2')
+    chai.expect(detail.set.mock.calls[0][1]).to.equal('${A} = 1and ${B} = 2')
+  })
+
+  it('keeps newlines for relevant (manual entry keeps them there too)', () => {
+    // Stored form keeps both field refs → a clean apply, newlines preserved.
+    const { row, detail } = makeFacadeRow(['', '${A} = 1\nand ${B} = 2'])
+    const outcome = applyExpressionToRow(row, 'relevant', '${A} = 1\nand ${B} = 2')
+    chai.expect(outcome).to.deep.equal({ status: 'applied' })
     chai.expect(detail.set.mock.calls[0][1]).to.equal('${A} = 1\nand ${B} = 2')
   })
 
-  it('does not report a mismatch when the facade only reformats (whitespace / quote style)', () => {
-    const { row, detail } = makeRow()
-    detail.getValue = jest.fn(() => "${A}=1 and ${B}='x'")
-    const outcome = applyExpressionToRow(row, 'relevant', '${A} = 1 and ${B} = "x"')
-    chai.expect(outcome).to.deep.equal({ status: 'applied', storedMismatch: null })
+  it('does not flag a date() wrapper the serializer adds (round-5 #3 false positive)', () => {
+    // DateOperator wraps a bare date literal in date('…') on serialize; the
+    // field ref ${visit_date} survives, so this is a clean apply, not a drop.
+    const { row } = makeFacadeRow(['', "${visit_date} > date('2024-01-01')"])
+    const outcome = applyExpressionToRow(row, 'constraint', "${visit_date} > '2024-01-01'")
+    chai.expect(outcome).to.deep.equal({ status: 'applied' })
   })
 
-  it('reports a mismatch when the facade drops a clause it cannot resolve', () => {
-    const { row, detail } = makeRow()
-    detail.getValue = jest.fn(() => '${A} = 1')
+  it('does not flag quotes the serializer adds around an unquoted value (round-5 #3)', () => {
+    // TextOperator wraps an unquoted value in quotes; ${subject_code} survives.
+    const { row } = makeFacadeRow(['', "${subject_code} = '123'"])
+    const outcome = applyExpressionToRow(row, 'constraint', '${subject_code} = 123')
+    chai.expect(outcome).to.deep.equal({ status: 'applied' })
+  })
+
+  it('refuses and reverts a partial clause-drop, reporting the unresolved refs (round-5 #5)', () => {
+    // The facade dropped the ${NOPE} clause it could not resolve. Rather than
+    // persist a silently-reduced expression, restore the previous value and
+    // report a rejection.
+    const previous = '${A} = 1'
+    const { row, detail } = makeFacadeRow([previous, '${A} = 1'])
     const outcome = applyExpressionToRow(row, 'constraint', '${A} = 1 and ${NOPE} = 2')
     chai.expect(outcome).to.deep.equal({
-      status: 'applied',
-      storedMismatch: { intended: '${A} = 1 and ${NOPE} = 2', stored: '${A} = 1' },
+      status: 'rejected',
+      intended: '${A} = 1 and ${NOPE} = 2',
+      stored: '${A} = 1',
+      unresolved: ['${NOPE}'],
     })
+    // Wrote the attempt, then restored the previous value (revert).
+    chai.expect(detail.set.mock.calls).to.deep.equal([
+      ['value', '${A} = 1 and ${NOPE} = 2'],
+      ['value', previous],
+    ])
   })
 
-  it('reports a mismatch when the facade serializes the whole expression away', () => {
-    const { row, detail } = makeRow()
-    detail.getValue = jest.fn(() => '')
+  it('refuses and reverts a total clause-drop', () => {
+    const { row, detail } = makeFacadeRow(['', ''])
     const outcome = applyExpressionToRow(row, 'relevant', '${AGE} >= 18')
-    chai.expect(outcome.status).to.equal('applied')
-    chai.expect((outcome as any).storedMismatch).to.deep.equal({ intended: '${AGE} >= 18', stored: '' })
+    chai.expect(outcome.status).to.equal('rejected')
+    chai.expect((outcome as any).unresolved).to.deep.equal(['${AGE}'])
+    chai.expect(detail.set.mock.calls).to.deep.equal([
+      ['value', '${AGE} >= 18'],
+      ['value', ''],
+    ])
   })
 
   it('does not consult getValue for non-facade attributes', () => {
     const { row, detail } = makeRow()
     detail.getValue = jest.fn(() => 'something else entirely')
     const outcome = applyExpressionToRow(row, 'calculation', '${A} + 1')
-    chai.expect(outcome).to.deep.equal({ status: 'applied', storedMismatch: null })
+    chai.expect(outcome).to.deep.equal({ status: 'applied' })
     chai.expect(detail.getValue.mock.calls.length).to.equal(0)
   })
 
@@ -125,6 +167,29 @@ describe('focusPanelInput (P1.3 AC4)', () => {
     chai.expect(document.activeElement?.className).to.equal('target')
   })
 
+  it('falls back to a mode-selector button when the panel has no input (round-5 #4)', () => {
+    // On a fully-collapsed skip-logic panel the only focusable control in
+    // .skiplogic__main is a mode-selector <button> — focus it rather than
+    // finding nothing.
+    document.body.innerHTML =
+      '<div class="js-card-settings-relevant-logic"><div class="skiplogic__main"><button class="mode">+ Add a condition</button></div></div>'
+    const focused = focusPanelInput('relevant')
+    chai.expect(focused).to.equal(true)
+    chai.expect(document.activeElement?.className).to.equal('mode')
+  })
+
+  it('scopes to the given root so a second open drawer is not hit (round-5 #2)', () => {
+    // Two rows expanded at once render the same class; a document-wide lookup
+    // would return whichever comes first in DOM order. Passing the row's own
+    // settings root disambiguates by row.
+    document.body.innerHTML =
+      '<div id="rowA" class="card__settings"><div class="js-card-settings-relevant-logic"><div class="skiplogic__main"><input class="a"></div></div></div>' +
+      '<div id="rowB" class="card__settings"><div class="js-card-settings-relevant-logic"><div class="skiplogic__main"><input class="b"></div></div></div>'
+    const rowB = document.getElementById('rowB')!
+    focusPanelInput('relevant', rowB)
+    chai.expect(document.activeElement?.className).to.equal('b')
+  })
+
   it('returns false for an unmapped attribute', () => {
     chai.expect(focusPanelInput('bogus')).to.equal(false)
   })
@@ -147,7 +212,6 @@ describe('focusGenerateButton (P1.1 AC6, dismiss)', () => {
   })
 
   it("focuses the panel's Generate button by its accessible name", () => {
-    // The GenerateButton renders aria-label `Generate <Label> with AI`.
     document.body.innerHTML =
       '<button aria-label="Generate Relevant Logic with AI">Generate</button>'
     const focused = focusGenerateButton('relevant')
@@ -163,6 +227,16 @@ describe('focusGenerateButton (P1.1 AC6, dismiss)', () => {
       '<button aria-label="Generate Constraint Logic with AI" id="target">g2</button>'
     focusGenerateButton('constraint')
     chai.expect((document.activeElement as HTMLElement)?.id).to.equal('target')
+  })
+
+  it('scopes to the given root so the right row is focused (round-5 #2)', () => {
+    // Same attribute, two rows; the row's settings root disambiguates.
+    document.body.innerHTML =
+      '<div id="rowA" class="card__settings"><button aria-label="Generate Relevant Logic with AI" id="a">g</button></div>' +
+      '<div id="rowB" class="card__settings"><button aria-label="Generate Relevant Logic with AI" id="b">g</button></div>'
+    const rowB = document.getElementById('rowB')!
+    focusGenerateButton('relevant', rowB)
+    chai.expect((document.activeElement as HTMLElement)?.id).to.equal('b')
   })
 
   it('returns false for an unmapped attribute', () => {

--- a/jsapp/js/openclinica/applyExpression.tests.ts
+++ b/jsapp/js/openclinica/applyExpression.tests.ts
@@ -1,5 +1,5 @@
 import chai from 'chai'
-import { applyExpressionToRow, focusPanelInput } from './applyExpression'
+import { applyExpressionToRow, focusPanelInput, focusGenerateButton } from './applyExpression'
 
 // Minimal Backbone-ish fakes: a row hands out a RowDetail via get(attribute)
 // and its survey via getSurvey(); the detail exposes set()/getValue().
@@ -131,6 +131,46 @@ describe('focusPanelInput (P1.3 AC4)', () => {
 
   it('returns false and warns when the input is not in the DOM', () => {
     chai.expect(focusPanelInput('calculation')).to.equal(false)
+    chai.expect(warnSpy.mock.calls.length).to.equal(1)
+  })
+})
+
+describe('focusGenerateButton (P1.1 AC6, dismiss)', () => {
+  let warnSpy: jest.SpyInstance
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    document.body.innerHTML = ''
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+    document.body.innerHTML = ''
+  })
+
+  it("focuses the panel's Generate button by its accessible name", () => {
+    // The GenerateButton renders aria-label `Generate <Label> with AI`.
+    document.body.innerHTML =
+      '<button aria-label="Generate Relevant Logic with AI">Generate</button>'
+    const focused = focusGenerateButton('relevant')
+    chai.expect(focused).to.equal(true)
+    chai.expect((document.activeElement as HTMLElement)?.getAttribute('aria-label')).to.equal(
+      'Generate Relevant Logic with AI',
+    )
+  })
+
+  it('scopes to the requested attribute when several Generate buttons are present', () => {
+    document.body.innerHTML =
+      '<button aria-label="Generate Calculation with AI">g1</button>' +
+      '<button aria-label="Generate Constraint Logic with AI" id="target">g2</button>'
+    focusGenerateButton('constraint')
+    chai.expect((document.activeElement as HTMLElement)?.id).to.equal('target')
+  })
+
+  it('returns false for an unmapped attribute', () => {
+    chai.expect(focusGenerateButton('bogus')).to.equal(false)
+  })
+
+  it('returns false and warns when no matching Generate button exists', () => {
+    chai.expect(focusGenerateButton('relevant')).to.equal(false)
     chai.expect(warnSpy.mock.calls.length).to.equal(1)
   })
 })

--- a/jsapp/js/openclinica/applyExpression.ts
+++ b/jsapp/js/openclinica/applyExpression.ts
@@ -9,9 +9,11 @@
 import { ATTRIBUTE_LABELS } from '@openclinica/logic-builder'
 import { columnToTab } from './logicBuilderTabs'
 
-// Only Calculation and Default block newlines on manual entry, so an applied
-// AI result is normalized only for those two (PR#273 round-1 #3).
-const NEWLINE_STRIPPING_ATTRIBUTES = new Set(['calculation', 'default'])
+// Attributes whose manual input strips newlines (single-line fields / Enter is
+// suppressed), so an applied AI result is normalized to match: Calculation and
+// Default (PR#273 round-1 #3) plus Required, whose panel input is single-line —
+// a multi-line value would write fine but become uneditable there (round-5 #7).
+const NEWLINE_STRIPPING_ATTRIBUTES = new Set(['calculation', 'default', 'required'])
 
 // Facade-backed attributes: RowDetail.getValue() for these returns
 // `facade.serialize()`, NOT the raw stored string — and the skip-logic builder
@@ -20,27 +22,53 @@ const NEWLINE_STRIPPING_ATTRIBUTES = new Set(['calculation', 'default'])
 // lose clauses with no error (PR#273 round-3).
 const FACADE_ATTRIBUTES = new Set(['relevant', 'constraint'])
 
-export interface StoredMismatch {
-  intended: string
-  stored: string
-}
-
 export type ApplyOutcome =
-  | { status: 'applied'; storedMismatch: StoredMismatch | null }
+  | { status: 'applied' }
+  // The facade could not represent every clause (it dropped one or more field
+  // references it can't resolve). The attempted write is reverted — nothing is
+  // persisted — and the unresolved references are reported (round-5 #5).
+  | { status: 'rejected'; intended: string; stored: string; unresolved: string[] }
   | { status: 'error'; reason: 'missing-detail' | 'detached-row' | 'write-failed' }
 
 /**
- * The serializer's formatting differs from raw typed text (operator spacing,
- * quote style), so compare with whitespace removed and quotes unified — a
- * heuristic: it only needs to catch real clause loss, not formatting drift.
+ * Field references (`${name}`) in an expression, in order, duplicates kept.
+ * These survive every legitimate reformatting the serializers apply — quote
+ * insertion (`123` → `'123'`), `date()` wrapping, operator spacing, the leading
+ * `.` a constraint gains — so comparing them is robust where a raw string
+ * compare produced false positives (round-5 #3). The one failure mode that
+ * matters here — the facade dropping a clause whose field it can't resolve —
+ * always removes that clause's `${ref}`.
  */
-function comparable(expression: string): string {
-  return expression.replace(/\s+/g, '').replace(/"/g, "'")
+function fieldRefs(expression: string): string[] {
+  return expression.match(/\$\{[^}]+\}/g) ?? []
+}
+
+/**
+ * Field references present in `intended` but missing from `stored` (multiset
+ * difference). Non-empty ⇒ the facade dropped at least one clause on serialize.
+ */
+function droppedFieldRefs(intended: string, stored: string): string[] {
+  const remaining = new Map<string, number>()
+  for (const ref of fieldRefs(stored)) {
+    remaining.set(ref, (remaining.get(ref) ?? 0) + 1)
+  }
+  const dropped: string[] = []
+  for (const ref of fieldRefs(intended)) {
+    const count = remaining.get(ref) ?? 0
+    if (count > 0) {
+      remaining.set(ref, count - 1)
+    } else {
+      dropped.push(ref)
+    }
+  }
+  return dropped
 }
 
 /**
  * Write an applied expression into a row's attribute (via the RowDetail
  * wrapper — never `row.set('<col>', …)`) and report what actually happened.
+ * For facade-backed attributes a lossy write (a clause the facade can't
+ * represent) is reverted rather than persisted (round-5 #5).
  */
 export function applyExpressionToRow(row: any, attribute: string, expression: string): ApplyOutcome {
   const detail = row?.get?.(attribute)
@@ -57,28 +85,37 @@ export function applyExpressionToRow(row: any, attribute: string, expression: st
   }
   try {
     const value = NEWLINE_STRIPPING_ATTRIBUTES.has(attribute) ? expression.replace(/\r?\n/g, '') : expression
-    detail.set('value', value)
-    // `relevant`/`constraint` are not in the auto-`change` whitelist, so
-    // trigger it explicitly (idempotent for every attribute) to enable Save.
-    survey.trigger?.('change')
     if (FACADE_ATTRIBUTES.has(attribute)) {
+      // Capture the serialized prior value so a lossy write can be reverted.
+      const previous = String(detail.getValue?.() ?? '')
+      detail.set('value', value)
+      // `relevant`/`constraint` are not in the auto-`change` whitelist, so
+      // trigger it explicitly (idempotent for every attribute) to enable Save.
+      survey.trigger?.('change')
       const stored = String(detail.getValue?.() ?? '')
-      if (comparable(stored) !== comparable(value)) {
-        return { status: 'applied', storedMismatch: { intended: value, stored } }
+      const unresolved = droppedFieldRefs(value, stored)
+      if (unresolved.length > 0) {
+        // Revert: never persist a silently-reduced expression.
+        detail.set('value', previous)
+        survey.trigger?.('change')
+        return { status: 'rejected', intended: value, stored, unresolved }
       }
+      return { status: 'applied' }
     }
-    return { status: 'applied', storedMismatch: null }
+    detail.set('value', value)
+    survey.trigger?.('change')
+    return { status: 'applied' }
   } catch (e) {
     console.error('Logic Builder: failed to apply generated expression', e)
     return { status: 'error', reason: 'write-failed' }
   }
 }
 
-// Per-attribute expression input inside the (single) open settings drawer.
-// Only one drawer can be open while the dialog is up — the whole builder is
-// inert behind it — so a document-level lookup is unambiguous. The facade
-// panels (relevant/constraint) have no single text input; focus their first
-// interactive control inside `.skiplogic__main`.
+// Per-attribute expression input inside a settings drawer. Scoped to a `root`
+// (the row's own `.card__settings`) by the caller so a second open drawer — or
+// a group + child row rendering the same class — can't be hit (round-5 #2).
+// The facade panels (relevant/constraint) have no single text input; focus
+// their first interactive control inside `.skiplogic__main`.
 const PANEL_INPUT_SELECTORS: Partial<Record<string, string>> = {
   calculation: '.js-calculation-input',
   default: '.js-default-value-input',
@@ -90,20 +127,33 @@ const PANEL_INPUT_SELECTORS: Partial<Record<string, string>> = {
     '.js-card-settings-validation-criteria .skiplogic__main select, .js-card-settings-validation-criteria .skiplogic__main textarea, .js-card-settings-validation-criteria .skiplogic__main input',
 }
 
+// Fallback when a facade panel has no input at all: a fully-collapsed skip-logic
+// panel renders only mode-selector <button>s in `.skiplogic__main` (round-5 #4).
+// Tried only after the primary (real input) selector misses, so a populated
+// panel always prefers its input over the "+ Add a condition" button.
+const PANEL_INPUT_FALLBACK_SELECTORS: Partial<Record<string, string>> = {
+  relevant: '.js-card-settings-relevant-logic .skiplogic__main button',
+  constraint: '.js-card-settings-validation-criteria .skiplogic__main button',
+}
+
 /**
  * Move focus to the panel's expression input after Apply (P1.3 AC4): "Apply
  * closes the dialog and moves focus to the panel's expression field". The
- * dialog deliberately skips its own focus-restore on Apply and defers to the
- * host — this is that hand-off. Call it only after the dialog has unmounted
- * and the builder's inert state is cleared (focusing an inert element is a
- * silent no-op).
+ * dialog defers focus-on-close to the host — this is that hand-off. Call it
+ * only after the dialog has unmounted and the builder's inert state is cleared
+ * (focusing an inert element is a silent no-op). Pass the row's settings root
+ * as `root` to disambiguate concurrently-open drawers (round-5 #2).
  */
 export function focusPanelInput(attribute: string, root: ParentNode = document): boolean {
   const selector = PANEL_INPUT_SELECTORS[attribute]
   if (!selector) {
     return false
   }
-  const el = root.querySelector<HTMLElement>(selector)
+  const el =
+    root.querySelector<HTMLElement>(selector) ??
+    (PANEL_INPUT_FALLBACK_SELECTORS[attribute]
+      ? root.querySelector<HTMLElement>(PANEL_INPUT_FALLBACK_SELECTORS[attribute] as string)
+      : null)
   if (!el) {
     console.warn('Logic Builder: could not find the panel input to focus after Apply', attribute)
     return false
@@ -117,10 +167,10 @@ export function focusPanelInput(attribute: string, root: ParentNode = document):
  * × / Escape) — P1.1 AC6, the counterpart to focusPanelInput for Apply.
  *
  * The dialog is embedded and the builder is made inert while it is open, so the
- * package's own captured-opener restore does not reliably land back on the
- * Generate button in this host (verified live). We own it here with a fresh
- * lookup — scoped to the attribute via the button's accessible name (set by the
- * package's GenerateButton) — after the dialog unmounts and inert clears.
+ * package no longer attempts its own focus restore — the host owns it. We do a
+ * fresh lookup scoped to the attribute via the button's accessible name (set by
+ * the package's GenerateButton), and to the row via `root` (round-5 #2), after
+ * the dialog unmounts and inert clears.
  */
 export function focusGenerateButton(attribute: string, root: ParentNode = document): boolean {
   const tab = columnToTab(attribute)

--- a/jsapp/js/openclinica/applyExpression.ts
+++ b/jsapp/js/openclinica/applyExpression.ts
@@ -1,0 +1,111 @@
+/**
+ * OC fork — P1.3 apply-path helpers for the Logic Builder AI Generator.
+ *
+ * Extracted from `EditableForm.tsx` so the write path is unit-testable without
+ * mounting the whole Form Designer component. `EditableForm` maps the returned
+ * outcome onto user-facing feedback (alertify) and dialog state; everything
+ * that touches the Backbone row lives here.
+ */
+
+// Only Calculation and Default block newlines on manual entry, so an applied
+// AI result is normalized only for those two (PR#273 round-1 #3).
+const NEWLINE_STRIPPING_ATTRIBUTES = new Set(['calculation', 'default'])
+
+// Facade-backed attributes: RowDetail.getValue() for these returns
+// `facade.serialize()`, NOT the raw stored string — and the skip-logic builder
+// silently DROPS any clause whose field it cannot resolve, then re-serializes
+// only what is left. Save persists getValue(), so an applied expression can
+// lose clauses with no error (PR#273 round-3).
+const FACADE_ATTRIBUTES = new Set(['relevant', 'constraint'])
+
+export interface StoredMismatch {
+  intended: string
+  stored: string
+}
+
+export type ApplyOutcome =
+  | { status: 'applied'; storedMismatch: StoredMismatch | null }
+  | { status: 'error'; reason: 'missing-detail' | 'detached-row' | 'write-failed' }
+
+/**
+ * The serializer's formatting differs from raw typed text (operator spacing,
+ * quote style), so compare with whitespace removed and quotes unified — a
+ * heuristic: it only needs to catch real clause loss, not formatting drift.
+ */
+function comparable(expression: string): string {
+  return expression.replace(/\s+/g, '').replace(/"/g, "'")
+}
+
+/**
+ * Write an applied expression into a row's attribute (via the RowDetail
+ * wrapper — never `row.set('<col>', …)`) and report what actually happened.
+ */
+export function applyExpressionToRow(row: any, attribute: string, expression: string): ApplyOutcome {
+  const detail = row?.get?.(attribute)
+  if (!detail?.set) {
+    return { status: 'error', reason: 'missing-detail' }
+  }
+  // A detached row (`BaseRow.detach()` nulls `_parent`) still hands out normal
+  // RowDetails, but `getSurvey()` returns null — the write would land on an
+  // orphan, `trigger('change')` would no-op, and Save would persist nothing
+  // while the dialog closed as if Apply worked (PR#273 round-3).
+  const survey = row.getSurvey?.()
+  if (!survey) {
+    return { status: 'error', reason: 'detached-row' }
+  }
+  try {
+    const value = NEWLINE_STRIPPING_ATTRIBUTES.has(attribute) ? expression.replace(/\r?\n/g, '') : expression
+    detail.set('value', value)
+    // `relevant`/`constraint` are not in the auto-`change` whitelist, so
+    // trigger it explicitly (idempotent for every attribute) to enable Save.
+    survey.trigger?.('change')
+    if (FACADE_ATTRIBUTES.has(attribute)) {
+      const stored = String(detail.getValue?.() ?? '')
+      if (comparable(stored) !== comparable(value)) {
+        return { status: 'applied', storedMismatch: { intended: value, stored } }
+      }
+    }
+    return { status: 'applied', storedMismatch: null }
+  } catch (e) {
+    console.error('Logic Builder: failed to apply generated expression', e)
+    return { status: 'error', reason: 'write-failed' }
+  }
+}
+
+// Per-attribute expression input inside the (single) open settings drawer.
+// Only one drawer can be open while the dialog is up — the whole builder is
+// inert behind it — so a document-level lookup is unambiguous. The facade
+// panels (relevant/constraint) have no single text input; focus their first
+// interactive control inside `.skiplogic__main`.
+const PANEL_INPUT_SELECTORS: Partial<Record<string, string>> = {
+  calculation: '.js-calculation-input',
+  default: '.js-default-value-input',
+  repeat_count: '.repeat-count-panel__input',
+  required: '.js-mandatory-setting-custom-text, .mandatory-setting-custom-text',
+  relevant:
+    '.js-card-settings-relevant-logic .skiplogic__main select, .js-card-settings-relevant-logic .skiplogic__main textarea, .js-card-settings-relevant-logic .skiplogic__main input',
+  constraint:
+    '.js-card-settings-validation-criteria .skiplogic__main select, .js-card-settings-validation-criteria .skiplogic__main textarea, .js-card-settings-validation-criteria .skiplogic__main input',
+}
+
+/**
+ * Move focus to the panel's expression input after Apply (P1.3 AC4): "Apply
+ * closes the dialog and moves focus to the panel's expression field". The
+ * dialog deliberately skips its own focus-restore on Apply and defers to the
+ * host — this is that hand-off. Call it only after the dialog has unmounted
+ * and the builder's inert state is cleared (focusing an inert element is a
+ * silent no-op).
+ */
+export function focusPanelInput(attribute: string, root: ParentNode = document): boolean {
+  const selector = PANEL_INPUT_SELECTORS[attribute]
+  if (!selector) {
+    return false
+  }
+  const el = root.querySelector<HTMLElement>(selector)
+  if (!el) {
+    console.warn('Logic Builder: could not find the panel input to focus after Apply', attribute)
+    return false
+  }
+  el.focus()
+  return true
+}

--- a/jsapp/js/openclinica/applyExpression.ts
+++ b/jsapp/js/openclinica/applyExpression.ts
@@ -86,8 +86,11 @@ export function applyExpressionToRow(row: any, attribute: string, expression: st
   try {
     const value = NEWLINE_STRIPPING_ATTRIBUTES.has(attribute) ? expression.replace(/\r?\n/g, '') : expression
     if (FACADE_ATTRIBUTES.has(attribute)) {
-      // Capture the serialized prior value so a lossy write can be reverted.
-      const previous = String(detail.getValue?.() ?? '')
+      // Capture the RAW stored value so a lossy write reverts to exactly what
+      // was there. getValue() is the facade's reserialization, which itself
+      // drops clauses it can't resolve — reverting to it would silently reduce
+      // pre-existing content while the toast claims nothing changed (round-7).
+      const previous = String(detail.get?.('value') ?? '')
       detail.set('value', value)
       // `relevant`/`constraint` are not in the auto-`change` whitelist, so
       // trigger it explicitly (idempotent for every attribute) to enable Save.

--- a/jsapp/js/openclinica/applyExpression.ts
+++ b/jsapp/js/openclinica/applyExpression.ts
@@ -6,6 +6,8 @@
  * outcome onto user-facing feedback (alertify) and dialog state; everything
  * that touches the Backbone row lives here.
  */
+import { ATTRIBUTE_LABELS } from '@openclinica/logic-builder'
+import { columnToTab } from './logicBuilderTabs'
 
 // Only Calculation and Default block newlines on manual entry, so an applied
 // AI result is normalized only for those two (PR#273 round-1 #3).
@@ -107,5 +109,29 @@ export function focusPanelInput(attribute: string, root: ParentNode = document):
     return false
   }
   el.focus()
+  return true
+}
+
+/**
+ * Move focus to the panel's Generate button after a *dismiss* close (Cancel /
+ * × / Escape) — P1.1 AC6, the counterpart to focusPanelInput for Apply.
+ *
+ * The dialog is embedded and the builder is made inert while it is open, so the
+ * package's own captured-opener restore does not reliably land back on the
+ * Generate button in this host (verified live). We own it here with a fresh
+ * lookup — scoped to the attribute via the button's accessible name (set by the
+ * package's GenerateButton) — after the dialog unmounts and inert clears.
+ */
+export function focusGenerateButton(attribute: string, root: ParentNode = document): boolean {
+  const tab = columnToTab(attribute)
+  if (!tab) {
+    return false
+  }
+  const btn = root.querySelector<HTMLElement>(`button[aria-label="Generate ${ATTRIBUTE_LABELS[tab]} with AI"]`)
+  if (!btn) {
+    console.warn('Logic Builder: could not find the Generate button to focus after dismiss', attribute)
+    return false
+  }
+  btn.focus()
   return true
 }

--- a/jsapp/js/openclinica/generateButtonBridge.tests.ts
+++ b/jsapp/js/openclinica/generateButtonBridge.tests.ts
@@ -1,0 +1,93 @@
+import chai from 'chai'
+
+// Capture every React root the bridge creates so the unmount semantics are
+// directly assertable. (Variables referenced from a jest.mock factory must be
+// prefixed with `mock`.)
+const mockRoots: Array<{ render: jest.Mock; unmount: jest.Mock }> = []
+jest.mock('react-dom/client', () => ({
+  createRoot: jest.fn(() => {
+    const root = { render: jest.fn(), unmount: jest.fn() }
+    mockRoots.push(root)
+    return root
+  }),
+}))
+jest.mock('#/stores', () => ({ stores: { surveyState: { setState: jest.fn() } } }))
+
+import { mountGenerateButton, unmountAll } from './generateButtonBridge'
+
+describe('generateButtonBridge (P1.1)', () => {
+  let warnSpy: jest.SpyInstance
+  let errorSpy: jest.SpyInstance
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    document.body.innerHTML = ''
+  })
+  afterEach(() => {
+    unmountAll() // reset the module-level tracked-roots registry between tests
+    mockRoots.length = 0
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    document.body.innerHTML = ''
+  })
+
+  it('mounts a Generate button root under the anchor', () => {
+    const anchor = document.createElement('div')
+    document.body.appendChild(anchor)
+    const mountEl = mountGenerateButton(anchor, { row: {}, attribute: 'calculation' })
+    chai.expect(mountEl).to.not.equal(null)
+    chai.expect(mountEl?.parentElement).to.equal(anchor)
+    chai.expect(mockRoots.length).to.equal(1)
+    chai.expect(mockRoots[0].render.mock.calls.length).to.equal(1)
+  })
+
+  it('warns and mounts nothing when the anchor cannot be resolved', () => {
+    const mountEl = mountGenerateButton(null, { row: {}, attribute: 'calculation' })
+    chai.expect(mountEl).to.equal(null)
+    chai.expect(mockRoots.length).to.equal(0)
+    chai.expect(warnSpy.mock.calls.length).to.equal(1)
+  })
+
+  it('warns and mounts nothing for an attribute with no tab mapping', () => {
+    const anchor = document.createElement('div')
+    document.body.appendChild(anchor)
+    const mountEl = mountGenerateButton(anchor, { row: {}, attribute: 'label' })
+    chai.expect(mountEl).to.equal(null)
+    chai.expect(anchor.children.length).to.equal(0)
+    chai.expect(warnSpy.mock.calls.length).to.equal(1)
+  })
+
+  it('unmountAll(scope) unmounts only the roots inside that scope', () => {
+    const anchorA = document.createElement('div')
+    const anchorB = document.createElement('div')
+    document.body.append(anchorA, anchorB)
+    mountGenerateButton(anchorA, { row: {}, attribute: 'calculation' })
+    mountGenerateButton(anchorB, { row: {}, attribute: 'relevant' })
+    unmountAll(anchorA)
+    chai.expect(mockRoots[0].unmount.mock.calls.length).to.equal(1)
+    chai.expect(mockRoots[1].unmount.mock.calls.length).to.equal(0)
+    chai.expect(anchorA.children.length).to.equal(0)
+    chai.expect(anchorB.children.length).to.equal(1)
+  })
+
+  it('unmountAll() with no scope unmounts every tracked root', () => {
+    const anchorA = document.createElement('div')
+    const anchorB = document.createElement('div')
+    document.body.append(anchorA, anchorB)
+    mountGenerateButton(anchorA, { row: {}, attribute: 'calculation' })
+    mountGenerateButton(anchorB, { row: {}, attribute: 'relevant' })
+    unmountAll()
+    chai.expect(mockRoots[0].unmount.mock.calls.length).to.equal(1)
+    chai.expect(mockRoots[1].unmount.mock.calls.length).to.equal(1)
+  })
+
+  it('unmountAll(unresolvable scope) logs an error and unmounts NOTHING (never escalates to unmount-everything)', () => {
+    const anchor = document.createElement('div')
+    document.body.appendChild(anchor)
+    mountGenerateButton(anchor, { row: {}, attribute: 'calculation' })
+    unmountAll({} as unknown) // a scope was requested but cannot be resolved
+    chai.expect(mockRoots[0].unmount.mock.calls.length).to.equal(0)
+    chai.expect(anchor.children.length).to.equal(1)
+    chai.expect(errorSpy.mock.calls.length).to.equal(1)
+  })
+})

--- a/jsapp/js/openclinica/generateButtonBridge.tsx
+++ b/jsapp/js/openclinica/generateButtonBridge.tsx
@@ -1,0 +1,119 @@
+/**
+ * OC fork — P1.3 Logic Builder "Generate" button bridge (Backbone <-> React).
+ *
+ * The xlform Form Designer settings drawer is hand-built jQuery/CoffeeScript.
+ * This module lets that CoffeeScript imperatively mount the package's
+ * `<GenerateButton>` into a given anchor element and, crucially, tear the React
+ * root back down when the drawer is cleaned up (`_cleanupExpandedRender`), so
+ * we never leak roots on drawer toggle.
+ *
+ * Clicking the button pushes a `generateRequest` onto the `stores.surveyState`
+ * Reflux store; `EditableForm.tsx` reads that to open the shared
+ * `<AiGeneratorDialog>`. See `logicBuilderTabs.ts` for the store key + mapping.
+ */
+import React from 'react'
+
+import { GenerateButton } from '@openclinica/logic-builder'
+import { createRoot, type Root } from 'react-dom/client'
+import { stores } from '#/stores'
+import { GENERATE_REQUEST_KEY, columnToTab } from './logicBuilderTabs'
+
+import '@openclinica/logic-builder/style.css'
+
+const MOUNT_CLASS = 'logic-builder-generate-mount'
+
+interface TrackedRoot {
+  mountEl: HTMLElement
+  root: Root
+}
+
+// Module-level registry of every React root we create, so we can unmount them
+// on drawer cleanup (the settings drawer has no unmount hook of its own).
+const trackedRoots: TrackedRoot[] = []
+
+interface MountOptions {
+  // Backbone Row model (xlform).
+  row: any
+  // xlform RowDetail column name, e.g. 'calculation' | 'relevant' | 'repeat_count'.
+  attribute: string
+}
+
+/** Accept a raw DOM element or a jQuery-like wrapper and return the DOM node. */
+function resolveEl(anchor: unknown): HTMLElement | null {
+  if (!anchor) {
+    return null
+  }
+  if (anchor instanceof HTMLElement) {
+    return anchor
+  }
+  const jq = anchor as { get?: (i: number) => HTMLElement; 0?: HTMLElement; length?: number }
+  if (typeof jq.get === 'function') {
+    return jq.get(0) || null
+  }
+  if (jq[0] instanceof HTMLElement) {
+    return jq[0]
+  }
+  return null
+}
+
+/**
+ * Mount a `<GenerateButton>` as a child of `anchor` for the given row+attribute.
+ * No-op for unmappable columns or a missing anchor. Returns the mount element.
+ */
+export function mountGenerateButton(anchor: unknown, options: MountOptions): HTMLElement | null {
+  const anchorEl = resolveEl(anchor)
+  if (!anchorEl) {
+    return null
+  }
+
+  const tab = columnToTab(options.attribute)
+  if (!tab) {
+    return null
+  }
+
+  const mountEl = document.createElement('span')
+  mountEl.className = MOUNT_CLASS
+  // Separate the button from the panel header title it sits beside, and keep
+  // it vertically centered against the header text.
+  mountEl.style.marginLeft = '12px'
+  mountEl.style.verticalAlign = 'middle'
+  anchorEl.appendChild(mountEl)
+
+  const root = createRoot(mountEl)
+  root.render(
+    <GenerateButton
+      attribute={tab}
+      onOpen={() => {
+        stores.surveyState.setState({
+          [GENERATE_REQUEST_KEY]: { row: options.row, attribute: options.attribute },
+        })
+      }}
+    />,
+  )
+
+  trackedRoots.push({ mountEl, root })
+  return mountEl
+}
+
+/**
+ * Unmount every tracked root whose mount element lives inside `scope` (or all of
+ * them when `scope` is omitted). Called from the settings-drawer cleanup so React
+ * roots don't leak when the drawer is torn down.
+ */
+export function unmountAll(scope?: unknown): void {
+  const scopeEl = resolveEl(scope)
+  for (let i = trackedRoots.length - 1; i >= 0; i -= 1) {
+    const tracked = trackedRoots[i]
+    const inScope = !scopeEl || scopeEl === tracked.mountEl || scopeEl.contains(tracked.mountEl)
+    if (!inScope) {
+      continue
+    }
+    try {
+      tracked.root.unmount()
+    } catch {
+      // ignore — already unmounted / detached
+    }
+    tracked.mountEl.remove()
+    trackedRoots.splice(i, 1)
+  }
+}

--- a/jsapp/js/openclinica/generateButtonBridge.tsx
+++ b/jsapp/js/openclinica/generateButtonBridge.tsx
@@ -93,8 +93,13 @@ export function mountGenerateButton(anchor: unknown, options: MountOptions): HTM
     <GenerateButton
       attribute={tab}
       onOpen={() => {
+        // Capture this row's own settings drawer so the host can scope its
+        // post-close focus lookup to it — `.closest` stops at the nearest
+        // ancestor, i.e. THIS row's `.card__settings`, never a sibling or
+        // parent group's (round-5 #2).
+        const settingsRoot = anchorEl.closest<HTMLElement>('.card__settings')
         stores.surveyState.setState({
-          [GENERATE_REQUEST_KEY]: { row: options.row, attribute: options.attribute },
+          [GENERATE_REQUEST_KEY]: { row: options.row, attribute: options.attribute, settingsRoot },
         })
       }}
     />,

--- a/jsapp/js/openclinica/generateButtonBridge.tsx
+++ b/jsapp/js/openclinica/generateButtonBridge.tsx
@@ -29,6 +29,11 @@ interface TrackedRoot {
 
 // Module-level registry of every React root we create, so we can unmount them
 // on drawer cleanup (the settings drawer has no unmount hook of its own).
+//
+// NOTE (PR#273 #8): jsapp/js/formbuild/renderInBackbone.js also mounts React
+// into Backbone views (renderKobomatrix), but it does not track or unmount its
+// roots (see its own open TODO). This bridge intentionally adds that lifecycle
+// management; folding the two into one shared helper is worthwhile follow-up.
 const trackedRoots: TrackedRoot[] = []
 
 interface MountOptions {
@@ -110,8 +115,10 @@ export function unmountAll(scope?: unknown): void {
     }
     try {
       tracked.root.unmount()
-    } catch {
-      // ignore — already unmounted / detached
+    } catch (e) {
+      // Most likely already unmounted / detached — but don't assume that; a
+      // real unmount failure should leave a trace rather than vanish (PR#273 #7).
+      console.error('Logic Builder: failed to unmount a Generate-button root', e)
     }
     tracked.mountEl.remove()
     trackedRoots.splice(i, 1)

--- a/jsapp/js/openclinica/generateButtonBridge.tsx
+++ b/jsapp/js/openclinica/generateButtonBridge.tsx
@@ -14,7 +14,7 @@
 import React from 'react'
 
 import { GenerateButton } from '@openclinica/logic-builder'
-import { createRoot, type Root } from 'react-dom/client'
+import { type Root, createRoot } from 'react-dom/client'
 import { stores } from '#/stores'
 import { GENERATE_REQUEST_KEY, columnToTab } from './logicBuilderTabs'
 

--- a/jsapp/js/openclinica/generateButtonBridge.tsx
+++ b/jsapp/js/openclinica/generateButtonBridge.tsx
@@ -1,5 +1,5 @@
 /**
- * OC fork — P1.3 Logic Builder "Generate" button bridge (Backbone <-> React).
+ * OC fork — P1.1 Logic Builder "Generate" button bridge (Backbone <-> React).
  *
  * The xlform Form Designer settings drawer is hand-built jQuery/CoffeeScript.
  * This module lets that CoffeeScript imperatively mount the package's
@@ -68,11 +68,15 @@ function resolveEl(anchor: unknown): HTMLElement | null {
 export function mountGenerateButton(anchor: unknown, options: MountOptions): HTMLElement | null {
   const anchorEl = resolveEl(anchor)
   if (!anchorEl) {
+    // A silent no-op here means a Generate button quietly stops appearing if a
+    // panel-header template class is ever renamed — leave a trace (PR#273).
+    console.warn('Logic Builder: Generate button anchor not found; not mounting', options.attribute)
     return null
   }
 
   const tab = columnToTab(options.attribute)
   if (!tab) {
+    console.warn('Logic Builder: no logic tab maps to attribute; not mounting Generate button', options.attribute)
     return null
   }
 
@@ -106,7 +110,17 @@ export function mountGenerateButton(anchor: unknown, options: MountOptions): HTM
  * roots don't leak when the drawer is torn down.
  */
 export function unmountAll(scope?: unknown): void {
-  const scopeEl = resolveEl(scope)
+  // Distinguish "no scope requested -> unmount everything" from "a scope was
+  // passed but couldn't be resolved". The only caller (_cleanupExpandedRender)
+  // always passes a scope, so a failed lookup (e.g. cleanup running after
+  // `.card__settings` was detached) must NOT silently escalate to unmounting
+  // every Generate-button root on the page — log it and skip this cleanup
+  // (PR#273 #4).
+  const scopeEl = scope === undefined ? undefined : resolveEl(scope)
+  if (scope !== undefined && !scopeEl) {
+    console.error('Logic Builder: unmountAll scope element could not be resolved; skipping cleanup', scope)
+    return
+  }
   for (let i = trackedRoots.length - 1; i >= 0; i -= 1) {
     const tracked = trackedRoots[i]
     const inScope = !scopeEl || scopeEl === tracked.mountEl || scopeEl.contains(tracked.mountEl)

--- a/jsapp/js/openclinica/logic-builder-stub/index.tsx
+++ b/jsapp/js/openclinica/logic-builder-stub/index.tsx
@@ -17,13 +17,7 @@
  */
 import type { RefObject } from 'react'
 
-export type ExpressionTab =
-  | 'calculation'
-  | 'default'
-  | 'constraint'
-  | 'required'
-  | 'relevant'
-  | 'repeatCount'
+export type ExpressionTab = 'calculation' | 'default' | 'constraint' | 'required' | 'relevant' | 'repeatCount'
 
 export interface FormFieldChoice {
   readonly value: string

--- a/jsapp/js/openclinica/logic-builder-stub/index.tsx
+++ b/jsapp/js/openclinica/logic-builder-stub/index.tsx
@@ -1,0 +1,105 @@
+/**
+ * OC fork — CI-only stand-in for the PRIVATE `@openclinica/logic-builder` package.
+ *
+ * `@openclinica/logic-builder` is an optionalDependency pinned to a private git
+ * ref. The public GitHub Actions CI (fork PRs, no secrets) can't clone it, so
+ * it's absent there. This stub is resolved ONLY when the real package isn't
+ * installed — see the presence-based fallbacks in `tsconfig.json` (`paths`),
+ * `webpack/webpack.common.js` (`resolve.alias`), and `jsapp/jest/unit.config.ts`
+ * (`moduleNameMapper`) — so type-check / build / unit tests stay green over all
+ * of kpi's own code without the private source.
+ *
+ * Local dev and the Jenkins/production image install the REAL package and never
+ * see this stub (the Dockerfile hard-fails if the real one is missing). The
+ * exported TYPES mirror the package's public surface faithfully so kpi's code is
+ * still type-checked in CI; the two components are inert (never rendered in CI).
+ * Keep in sync with the pinned logic-builder version.
+ */
+import type { RefObject } from 'react'
+
+export type ExpressionTab =
+  | 'calculation'
+  | 'default'
+  | 'constraint'
+  | 'required'
+  | 'relevant'
+  | 'repeatCount'
+
+export interface FormFieldChoice {
+  readonly value: string
+  readonly label: string
+}
+
+export interface FormField {
+  readonly name: string
+  readonly type: string
+  readonly label: string
+  readonly choices?: readonly FormFieldChoice[]
+}
+
+export interface FormFieldContext {
+  readonly fields: readonly FormField[]
+}
+
+export interface GenerationRequest {
+  readonly prompt: string
+  readonly attribute: ExpressionTab
+  readonly targetFieldName: string
+  readonly fields: FormFieldContext
+  readonly currentExpression: string
+}
+
+export interface GenerationSuccess {
+  readonly kind: 'success'
+  readonly expression: string
+}
+
+export interface GenerationFailure {
+  readonly kind: 'failure'
+  readonly error: string
+}
+
+export type GenerationResult = GenerationSuccess | GenerationFailure
+
+export interface GenerateClient {
+  generate(req: GenerationRequest, opts?: { readonly signal?: AbortSignal }): Promise<GenerationResult>
+}
+
+export const ATTRIBUTE_LABELS: Record<ExpressionTab, string> = {
+  calculation: 'Calculation',
+  default: 'Default Value',
+  constraint: 'Constraint Logic',
+  required: 'Required Logic',
+  relevant: 'Relevant Logic',
+  repeatCount: 'Repeat Count',
+}
+
+export interface GenerateButtonProps {
+  readonly attribute: ExpressionTab
+  readonly onOpen: () => void
+  readonly disabled?: boolean
+}
+
+// Inert stand-in — CI never renders this; the real package supplies the UI.
+export function GenerateButton(_props: GenerateButtonProps): JSX.Element | null {
+  return null
+}
+
+export interface AiGeneratorDialogProps {
+  readonly open: boolean
+  readonly scope: {
+    readonly itemName: string
+    readonly attribute: ExpressionTab
+    readonly fields: FormFieldContext
+    readonly currentExpression: string
+  }
+  readonly client: GenerateClient
+  readonly inertRoot?: RefObject<HTMLElement> | HTMLElement | null
+  readonly container?: HTMLElement | null
+  readonly onApply: (expression: string) => boolean | Promise<boolean>
+  readonly onClose: () => void
+}
+
+export function AiGeneratorDialog(_props: AiGeneratorDialogProps): JSX.Element | null {
+  return null
+}

--- a/jsapp/js/openclinica/logic-builder-stub/style.css
+++ b/jsapp/js/openclinica/logic-builder-stub/style.css
@@ -1,0 +1,3 @@
+/* CI-only stand-in for `@openclinica/logic-builder/style.css` (see index.tsx).
+   The real package ships the actual styles; this empty file just lets webpack
+   resolve the side-effect CSS import when the private package is absent. */

--- a/jsapp/js/openclinica/logicBuilderStubClient.tests.ts
+++ b/jsapp/js/openclinica/logicBuilderStubClient.tests.ts
@@ -1,0 +1,64 @@
+import chai from 'chai'
+import type { GenerationRequest } from '@openclinica/logic-builder'
+import { logicBuilderStubClient } from './logicBuilderStubClient'
+
+function makeRequest(overrides: Partial<GenerationRequest> = {}): GenerationRequest {
+  return {
+    prompt: 'calculate bmi',
+    attribute: 'calculation',
+    targetFieldName: 'BMI',
+    fields: { fields: [] },
+    currentExpression: '',
+    ...overrides,
+  }
+}
+
+describe('logicBuilderStubClient (P1.1)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('resolves a kind: success result after the stub delay', async () => {
+    const promise = logicBuilderStubClient.generate(makeRequest())
+    jest.advanceTimersByTime(400)
+    const result = await promise
+    chai.expect(result.kind).to.equal('success')
+    chai.expect((result as any).expression).to.be.a('string').and.not.equal('')
+  })
+
+  it('resolves a labeled kind: failure when the prompt contains "fail"', async () => {
+    const promise = logicBuilderStubClient.generate(makeRequest({ prompt: 'please fail' }))
+    jest.advanceTimersByTime(400)
+    const result = await promise
+    chai.expect(result.kind).to.equal('failure')
+    chai.expect((result as any).error).to.be.a('string').and.not.equal('')
+  })
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    let error: any
+    try {
+      await logicBuilderStubClient.generate(makeRequest(), { signal: controller.signal })
+    } catch (e) {
+      error = e
+    }
+    chai.expect(error?.name).to.equal('AbortError')
+  })
+
+  it('cancels a pending generation when the signal aborts mid-flight', async () => {
+    const controller = new AbortController()
+    const promise = logicBuilderStubClient.generate(makeRequest(), { signal: controller.signal })
+    const caught = promise.catch((e) => e)
+    controller.abort()
+    const error = await caught
+    chai.expect(error?.name).to.equal('AbortError')
+    // The pending timer was cleared — advancing time must not do anything
+    // further (a late resolve after rejection would be a no-op anyway, but the
+    // timer itself should be gone).
+    chai.expect(jest.getTimerCount()).to.equal(0)
+  })
+})

--- a/jsapp/js/openclinica/logicBuilderStubClient.tests.ts
+++ b/jsapp/js/openclinica/logicBuilderStubClient.tests.ts
@@ -1,5 +1,5 @@
-import chai from 'chai'
 import type { GenerationRequest } from '@openclinica/logic-builder'
+import chai from 'chai'
 import { logicBuilderStubClient } from './logicBuilderStubClient'
 
 function makeRequest(overrides: Partial<GenerationRequest> = {}): GenerationRequest {
@@ -26,7 +26,10 @@ describe('logicBuilderStubClient (P1.1)', () => {
     jest.advanceTimersByTime(400)
     const result = await promise
     chai.expect(result.kind).to.equal('success')
-    chai.expect((result as any).expression).to.be.a('string').and.not.equal('')
+    chai
+      .expect((result as any).expression)
+      .to.be.a('string')
+      .and.not.equal('')
   })
 
   it('resolves a labeled kind: failure when the prompt contains "fail"', async () => {
@@ -34,7 +37,10 @@ describe('logicBuilderStubClient (P1.1)', () => {
     jest.advanceTimersByTime(400)
     const result = await promise
     chai.expect(result.kind).to.equal('failure')
-    chai.expect((result as any).error).to.be.a('string').and.not.equal('')
+    chai
+      .expect((result as any).error)
+      .to.be.a('string')
+      .and.not.equal('')
   })
 
   it('rejects immediately when the signal is already aborted', async () => {

--- a/jsapp/js/openclinica/logicBuilderStubClient.ts
+++ b/jsapp/js/openclinica/logicBuilderStubClient.ts
@@ -1,0 +1,48 @@
+/**
+ * OC fork — P1.3 AI Generator (Logic Builder) STUB client.
+ *
+ * A stand-in for the eventual real AI generation backend. It returns a canned,
+ * attribute-appropriate XPath-ish expression after a short delay so the
+ * `AiGeneratorDialog` flow (loading -> proposal -> Apply) can be exercised
+ * end-to-end without a server. It intentionally rejects when the prompt
+ * contains the word "fail" so the dialog's error state is reachable too.
+ *
+ * NOTE: the `${...}` sequences below are LITERAL expression placeholders, not
+ * JS template interpolation — hence single-quoted strings throughout.
+ */
+import type { GenerateClient, GenerationRequest, GenerationResult } from '@openclinica/logic-builder'
+
+const STUB_DELAY_MS = 400
+
+export const logicBuilderStubClient: GenerateClient = {
+  generate(req: GenerationRequest): Promise<GenerationResult> {
+    return new Promise<GenerationResult>((resolve, reject) => {
+      setTimeout(() => {
+        const prompt = (req.prompt || '').toLowerCase()
+
+        if (prompt.includes('fail')) {
+          reject(new Error('Stub generation failed on purpose (prompt contained "fail").'))
+          return
+        }
+
+        let expression: string
+        if (prompt.includes('round')) {
+          expression = 'round(${WEIGHT} div pow(${HEIGHT} div 100, 2), 1)'
+        } else if (req.attribute === 'constraint' || req.attribute === 'relevant' || req.attribute === 'required') {
+          expression = '${AGE} >= 18'
+        } else if (req.attribute === 'repeatCount') {
+          expression = '${NUM_VISITS} + 2'
+        } else if (req.attribute === 'default') {
+          expression = 'today()'
+        } else {
+          // calculation (and any future/unknown attribute)
+          expression = '${WEIGHT} div pow(${HEIGHT} div 100, 2)'
+        }
+
+        resolve({ expression })
+      }, STUB_DELAY_MS)
+    })
+  },
+}
+
+export default logicBuilderStubClient

--- a/jsapp/js/openclinica/logicBuilderStubClient.ts
+++ b/jsapp/js/openclinica/logicBuilderStubClient.ts
@@ -4,8 +4,16 @@
  * A stand-in for the eventual real AI generation backend. It returns a canned,
  * attribute-appropriate XPath-ish expression after a short delay so the
  * `AiGeneratorDialog` flow (loading -> proposal -> Apply) can be exercised
- * end-to-end without a server. It intentionally rejects when the prompt
- * contains the word "fail" so the dialog's error state is reachable too.
+ * end-to-end without a server.
+ *
+ * It follows the package's updated GenerateClient contract:
+ *  - it honours the optional AbortSignal, so a superseded or abandoned request
+ *    is actually cancelled (its pending timer is cleared) rather than only
+ *    having its result ignored by the dialog; and
+ *  - it reports an intentional failure as a labeled `GenerationFailure`
+ *    (`{ error }`) — reachable by putting the word "fail" in the prompt —
+ *    instead of an unlabeled promise rejection, so the caller can tell a
+ *    failure apart from an empty-but-successful expression.
  *
  * NOTE: the `${...}` sequences below are LITERAL expression placeholders, not
  * JS template interpolation — hence single-quoted strings throughout.
@@ -15,13 +23,22 @@ import type { GenerateClient, GenerationRequest, GenerationResult } from '@openc
 const STUB_DELAY_MS = 400
 
 export const logicBuilderStubClient: GenerateClient = {
-  generate(req: GenerationRequest): Promise<GenerationResult> {
+  generate(req: GenerationRequest, opts?: { signal?: AbortSignal }): Promise<GenerationResult> {
+    const signal = opts?.signal
     return new Promise<GenerationResult>((resolve, reject) => {
-      setTimeout(() => {
+      // Already cancelled before we even start — bail immediately.
+      if (signal?.aborted) {
+        reject(new DOMException('Generation aborted', 'AbortError'))
+        return
+      }
+
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort)
         const prompt = (req.prompt || '').toLowerCase()
 
         if (prompt.includes('fail')) {
-          reject(new Error('Stub generation failed on purpose (prompt contained "fail").'))
+          // Labeled failure shape — distinguishable from an empty success.
+          resolve({ error: 'Stub generation failed on purpose (prompt contained "fail").' })
           return
         }
 
@@ -41,6 +58,14 @@ export const logicBuilderStubClient: GenerateClient = {
 
         resolve({ expression })
       }, STUB_DELAY_MS)
+
+      // Cancel the pending "request" when the dialog supersedes it (a newer
+      // Generate) or closes/unmounts — the package aborts in all three cases.
+      function onAbort() {
+        clearTimeout(timer)
+        reject(new DOMException('Generation aborted', 'AbortError'))
+      }
+      signal?.addEventListener('abort', onAbort, { once: true })
     })
   },
 }

--- a/jsapp/js/openclinica/logicBuilderStubClient.ts
+++ b/jsapp/js/openclinica/logicBuilderStubClient.ts
@@ -1,5 +1,5 @@
 /**
- * OC fork — P1.3 AI Generator (Logic Builder) STUB client.
+ * OC fork — P1.1 AI Generator (Logic Builder) STUB client.
  *
  * A stand-in for the eventual real AI generation backend. It returns a canned,
  * attribute-appropriate XPath-ish expression after a short delay so the
@@ -11,9 +11,9 @@
  *    is actually cancelled (its pending timer is cleared) rather than only
  *    having its result ignored by the dialog; and
  *  - it reports an intentional failure as a labeled `GenerationFailure`
- *    (`{ error }`) — reachable by putting the word "fail" in the prompt —
- *    instead of an unlabeled promise rejection, so the caller can tell a
- *    failure apart from an empty-but-successful expression.
+ *    (`{ kind: 'failure', error }`) — reachable by putting the word "fail" in
+ *    the prompt — instead of an unlabeled promise rejection, so the caller can
+ *    tell a failure apart from an empty-but-successful expression.
  *
  * NOTE: the `${...}` sequences below are LITERAL expression placeholders, not
  * JS template interpolation — hence single-quoted strings throughout.
@@ -38,7 +38,7 @@ export const logicBuilderStubClient: GenerateClient = {
 
         if (prompt.includes('fail')) {
           // Labeled failure shape — distinguishable from an empty success.
-          resolve({ error: 'Stub generation failed on purpose (prompt contained "fail").' })
+          resolve({ kind: 'failure', error: 'Stub generation failed on purpose (prompt contained "fail").' })
           return
         }
 
@@ -56,7 +56,7 @@ export const logicBuilderStubClient: GenerateClient = {
           expression = '${WEIGHT} div pow(${HEIGHT} div 100, 2)'
         }
 
-        resolve({ expression })
+        resolve({ kind: 'success', expression })
       }, STUB_DELAY_MS)
 
       // Cancel the pending "request" when the dialog supersedes it (a newer

--- a/jsapp/js/openclinica/logicBuilderTabs.tests.ts
+++ b/jsapp/js/openclinica/logicBuilderTabs.tests.ts
@@ -1,0 +1,22 @@
+import chai from 'chai'
+import { GENERATE_REQUEST_KEY, columnToTab } from './logicBuilderTabs'
+
+describe('logicBuilderTabs (P1.1)', () => {
+  it('maps every xlform logic column to its package tab', () => {
+    chai.expect(columnToTab('calculation')).to.equal('calculation')
+    chai.expect(columnToTab('default')).to.equal('default')
+    chai.expect(columnToTab('constraint')).to.equal('constraint')
+    chai.expect(columnToTab('required')).to.equal('required')
+    chai.expect(columnToTab('relevant')).to.equal('relevant')
+    chai.expect(columnToTab('repeat_count')).to.equal('repeatCount')
+  })
+
+  it('returns undefined for an unknown column', () => {
+    chai.expect(columnToTab('label')).to.equal(undefined)
+    chai.expect(columnToTab('')).to.equal(undefined)
+  })
+
+  it('exposes the surveyState key the dialog wiring depends on', () => {
+    chai.expect(GENERATE_REQUEST_KEY).to.equal('generateRequest')
+  })
+})

--- a/jsapp/js/openclinica/logicBuilderTabs.ts
+++ b/jsapp/js/openclinica/logicBuilderTabs.ts
@@ -32,4 +32,8 @@ export interface GenerateRequest {
   row: any
   // xlform column name, e.g. 'calculation' | 'relevant' | 'repeat_count'.
   attribute: string
+  // The row's own settings drawer (`.card__settings`), captured when the
+  // Generate button opened the dialog. Scopes the post-close focus lookup to
+  // this row so a second open drawer can't be hit (round-5 #2).
+  settingsRoot?: HTMLElement | null
 }

--- a/jsapp/js/openclinica/logicBuilderTabs.ts
+++ b/jsapp/js/openclinica/logicBuilderTabs.ts
@@ -1,5 +1,5 @@
 /**
- * OC fork — P1.3 Logic Builder mapping helpers.
+ * OC fork — P1.1 Logic Builder mapping helpers.
  *
  * Bridges the xlform world (Backbone RowDetail column names) and the
  * `@openclinica/logic-builder` package's `ExpressionTab` union. Every column
@@ -21,24 +21,9 @@ const COLUMN_TO_TAB: Partial<Record<string, ExpressionTab>> = {
   repeat_count: 'repeatCount',
 }
 
-/** package ExpressionTab -> xlform RowDetail column name. */
-const TAB_TO_COLUMN: Record<ExpressionTab, string> = {
-  calculation: 'calculation',
-  default: 'default',
-  constraint: 'constraint',
-  required: 'required',
-  relevant: 'relevant',
-  repeatCount: 'repeat_count',
-}
-
 /** Map an xlform column name to a package tab. Returns `undefined` if unknown. */
 export function columnToTab(column: string): ExpressionTab | undefined {
   return COLUMN_TO_TAB[column]
-}
-
-/** Map a package tab back to its xlform column name. */
-export function tabToColumn(tab: ExpressionTab): string {
-  return TAB_TO_COLUMN[tab]
 }
 
 /** Shape stored on `stores.surveyState[GENERATE_REQUEST_KEY]` while the dialog is open. */

--- a/jsapp/js/openclinica/logicBuilderTabs.ts
+++ b/jsapp/js/openclinica/logicBuilderTabs.ts
@@ -1,0 +1,50 @@
+/**
+ * OC fork — P1.3 Logic Builder mapping helpers.
+ *
+ * Bridges the xlform world (Backbone RowDetail column names) and the
+ * `@openclinica/logic-builder` package's `ExpressionTab` union. Every column
+ * name matches its tab name except `repeat_count` <-> `repeatCount`.
+ */
+import type { ExpressionTab } from '@openclinica/logic-builder'
+
+/** Key used on the `stores.surveyState` Reflux store to open/close the dialog. */
+export const GENERATE_REQUEST_KEY = 'generateRequest'
+
+/** xlform RowDetail column name -> package ExpressionTab. Partial so an
+ * unknown column correctly types the lookup as `ExpressionTab | undefined`. */
+const COLUMN_TO_TAB: Partial<Record<string, ExpressionTab>> = {
+  calculation: 'calculation',
+  default: 'default',
+  constraint: 'constraint',
+  required: 'required',
+  relevant: 'relevant',
+  repeat_count: 'repeatCount',
+}
+
+/** package ExpressionTab -> xlform RowDetail column name. */
+const TAB_TO_COLUMN: Record<ExpressionTab, string> = {
+  calculation: 'calculation',
+  default: 'default',
+  constraint: 'constraint',
+  required: 'required',
+  relevant: 'relevant',
+  repeatCount: 'repeat_count',
+}
+
+/** Map an xlform column name to a package tab. Returns `undefined` if unknown. */
+export function columnToTab(column: string): ExpressionTab | undefined {
+  return COLUMN_TO_TAB[column]
+}
+
+/** Map a package tab back to its xlform column name. */
+export function tabToColumn(tab: ExpressionTab): string {
+  return TAB_TO_COLUMN[tab]
+}
+
+/** Shape stored on `stores.surveyState[GENERATE_REQUEST_KEY]` while the dialog is open. */
+export interface GenerateRequest {
+  // Backbone Row model (xlform). Typed loosely to avoid pulling coffee types.
+  row: any
+  // xlform column name, e.g. 'calculation' | 'relevant' | 'repeat_count'.
+  attribute: string
+}

--- a/jsapp/js/stores.d.ts
+++ b/jsapp/js/stores.d.ts
@@ -28,9 +28,10 @@ export interface SurveyStateStore {
 
   /**
    * Reflux method: specific to the older createStore syntax.
-   * Allows components to listen to store updates.
+   * Allows components to listen to store updates. Returns an unsubscribe
+   * function (Reflux's listen contract) — call it to stop listening.
    */
-  listen(callback: (changes: any) => void): void
+  listen(callback: (changes: any) => void): () => void
 }
 
 export interface Stores {

--- a/jsapp/xlform/src/mv.validationLogicHelpers.coffee
+++ b/jsapp/xlform/src/mv.validationLogicHelpers.coffee
@@ -76,10 +76,16 @@ module.exports = do ->
   class validationLogicHelpers.ValidationLogicHandCodeHelper extends $skipLogicHelpers.SkipLogicHandCodeHelper
     @criteria_value = @criteria
     render: ($destination) ->
-      $destination.replaceWith(@$handCode)
+      # OC fork (PR#273 round-7): render INTO the destination like the skip-logic
+      # hand-code helper — replaceWith() detached the constraint panel's render
+      # anchor (.skiplogic__main), so every later change:value re-render landed in
+      # the detached node, and this input sat outside the .skiplogic__main scope
+      # the post-Apply focus lookup searches. The helper context empties the
+      # destination before each render, so nothing accumulates; the mode-selector
+      # button no longer needs to swap the anchor back, only to switch helpers.
+      $destination.append(@$handCode)
       @button.render().attach_to @$handCode
       @button.bind_event 'click', () =>
-        @$handCode.replaceWith($destination)
         @context.use_mode_selector_helper()
       @$handCode.on('change', () =>
         @criteria = @criteria_value.replace(/&quot;/g, '"');

--- a/jsapp/xlform/src/view.mandatorySetting.coffee
+++ b/jsapp/xlform/src/view.mandatorySetting.coffee
@@ -3,6 +3,7 @@ Backbone = require 'backbone'
 $configs = require './model.configs'
 $baseView = require './view.pluggedIn.backboneView'
 $viewTemplates = require './view.templates'
+generateButtonBridge = require '#/openclinica/generateButtonBridge'
 
 module.exports = do ->
   class MandatorySettingView extends $baseView
@@ -48,6 +49,11 @@ module.exports = do ->
       @$el.appendTo(rowView.defaultRowDetailParent)
       @$panelEl = $($viewTemplates.$$render('row.requiredLogicPanel'))
       @$panelEl.appendTo(rowView.cardSettingsWrap.find('.js-card-settings-required-logic'))
+      # OC fork (P1.3): AI Generate button in the Required Logic panel header.
+      generateButtonBridge.mountGenerateButton(
+        @$panelEl.find('.required-logic-panel__header').get(0)
+        { row: @model._parent, attribute: 'required' }
+      )
       @_bindPanelEvents()
       # Populate panel input with existing value if conditional
       reqVal = @getChangedValue()

--- a/jsapp/xlform/src/view.mandatorySetting.coffee
+++ b/jsapp/xlform/src/view.mandatorySetting.coffee
@@ -49,7 +49,7 @@ module.exports = do ->
       @$el.appendTo(rowView.defaultRowDetailParent)
       @$panelEl = $($viewTemplates.$$render('row.requiredLogicPanel'))
       @$panelEl.appendTo(rowView.cardSettingsWrap.find('.js-card-settings-required-logic'))
-      # OC fork (P1.3): AI Generate button in the Required Logic panel header.
+      # OC fork (P1.1): AI Generate button in the Required Logic panel header.
       generateButtonBridge.mountGenerateButton(
         @$panelEl.find('.required-logic-panel__header').get(0)
         { row: @model._parent, attribute: 'required' }

--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -12,6 +12,7 @@ $viewMandatorySetting = require('./view.mandatorySetting')
 $acceptedFilesView = require('./view.acceptedFiles')
 $viewRowDetail = require('./view.rowDetail')
 renderKobomatrix = require('#/formbuild/renderInBackbone').renderKobomatrix
+generateButtonBridge = require('#/openclinica/generateButtonBridge')
 hasRowRestriction = require('#/components/locking/lockingUtils').hasRowRestriction
 getRowLockingProfile = require('#/components/locking/lockingUtils').getRowLockingProfile
 isRowLocked = require('#/components/locking/lockingUtils').isRowLocked
@@ -426,6 +427,14 @@ module.exports = do ->
       ``
 
     _cleanupExpandedRender: ->
+      # OC fork (P1.3): unmount any Logic Builder "Generate" React roots mounted
+      # into this drawer before detaching it, so React roots don't leak.
+      generateButtonBridge.unmountAll(@$('.card__settings').get(0))
+      # OC fork (P1.3): tear down the model listeners registered via @listenTo
+      # in _expandedRender (e.g. the calculation/default/repeat_count panel
+      # live-refresh bindings) so re-opening the drawer doesn't accumulate
+      # duplicate handlers bound to stale, detached inputs.
+      @stopListening()
       @$('.card__settings').detach()
 
     clone: (event) ->
@@ -803,6 +812,11 @@ module.exports = do ->
         @cardSettingsWrap.find('.js-default-value-tab').removeClass('default-value-tab--hidden')
         $defaultPanel = $($viewTemplates.$$render('row.defaultValuePanel'))
         $defaultPanel.appendTo(@cardSettingsWrap.find('.js-card-settings-default-value'))
+        # OC fork (P1.3): AI Generate button in the Default Value panel header.
+        generateButtonBridge.mountGenerateButton(
+          $defaultPanel.find('.default-value-panel__header').get(0)
+          { row: @model, attribute: 'default' }
+        )
         $defaultTextarea = $defaultPanel.find('.js-default-value-input')
         currentVal = defaultModel.get('value') or ''
         $defaultTextarea.val(currentVal)
@@ -822,6 +836,24 @@ module.exports = do ->
             evt.preventDefault()
             $defaultTextarea.blur()
 
+        # OC fork (P1.3): keep the visible field in sync when the AI dialog's
+        # Apply writes directly to the model — otherwise the textarea still
+        # shows whatever it had at drawer-open time until the drawer is
+        # closed/reopened. Guarded by a value comparison so the user's own
+        # typing (which already wrote this exact value via updateDefaultModel
+        # above) never re-triggers a redundant DOM write. Bound via listenTo
+        # so _cleanupExpandedRender's @stopListening() removes it on close,
+        # instead of accumulating a new handler on every drawer open.
+        refreshDefaultInput = ->
+          modelVal = defaultModel.get('value') or ''
+          if $defaultTextarea.val() isnt modelVal
+            $defaultTextarea.val(modelVal)
+            if modelVal
+              scrollHeight = $defaultTextarea.prop('scrollHeight')
+              $defaultTextarea.css('height', '')
+              $defaultTextarea.css('height', scrollHeight)
+        @listenTo(defaultModel, 'change:value', refreshDefaultInput)
+
       # Calculation panel setup
       typesWithoutCalculation = ['note', 'image', 'audio', 'video', 'file']
       calculationModel = @model.get('calculation')
@@ -830,6 +862,11 @@ module.exports = do ->
         @cardSettingsWrap.find('.js-calculation-tab').removeClass('calculation-tab--hidden')
         $calcPanel = $($viewTemplates.$$render('row.calculationPanel'))
         $calcPanel.appendTo(@cardSettingsWrap.find('.js-card-settings-calculation'))
+        # OC fork (P1.3): AI Generate button in the Calculation panel header.
+        generateButtonBridge.mountGenerateButton(
+          $calcPanel.find('.calculation-panel__header').get(0)
+          { row: @model, attribute: 'calculation' }
+        )
 
         $calcTextarea = $calcPanel.find('.js-calculation-input')
         currentCalcVal = calculationModel.get('value') or ''
@@ -851,6 +888,20 @@ module.exports = do ->
           if evt.key is 'Enter' or evt.keyCode is 13
             evt.preventDefault()
             $calcTextarea.blur()
+
+        # OC fork (P1.3): keep the visible field in sync when the AI dialog's
+        # Apply writes directly to the model — see matching comment above
+        # refreshDefaultInput for the full rationale (guarded write, listenTo
+        # + @stopListening() teardown in _cleanupExpandedRender).
+        refreshCalculationInput = ->
+          modelVal = calculationModel.get('value') or ''
+          if $calcTextarea.val() isnt modelVal
+            $calcTextarea.val(modelVal)
+            if modelVal
+              scrollHeight = $calcTextarea.prop('scrollHeight')
+              $calcTextarea.css('height', '')
+              $calcTextarea.css('height', scrollHeight)
+        @listenTo(calculationModel, 'change:value', refreshCalculationInput)
 
         $calcTabError = @cardSettingsWrap.find('.js-calculation-tab-error')
         updateCalcTabError = ->

--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -427,10 +427,20 @@ module.exports = do ->
       ``
 
     _cleanupExpandedRender: ->
-      # OC fork (P1.3): unmount any Logic Builder "Generate" React roots mounted
+      # OC fork (P1.1): unmount any Logic Builder "Generate" React roots mounted
       # into this drawer before detaching it, so React roots don't leak.
-      generateButtonBridge.unmountAll(@$('.card__settings').get(0))
-      # OC fork (P1.3): tear down the model listeners registered via @listenTo
+      # Scope with @cardSettingsWrap — the node captured at expand time that
+      # the buttons were mounted under — NOT a fresh `.card__settings` query:
+      # an unscoped query can match a nested child row's drawer, and an empty
+      # query's `.get(0)` is `undefined`, which unmountAll reads as "unmount
+      # everything on the page" (PR#273 round-3). If the node is gone, skip —
+      # the Form Designer teardown's unscoped unmountAll() sweeps leftovers.
+      scopeEl = @cardSettingsWrap?.get(0)
+      if scopeEl
+        generateButtonBridge.unmountAll(scopeEl)
+      else
+        console.warn('Logic Builder: no settings wrap captured for this drawer; skipping scoped Generate-button cleanup')
+      # OC fork (P1.1): tear down the model listeners registered via @listenTo
       # in _expandedRender (e.g. the calculation/default/repeat_count panel
       # live-refresh bindings) so re-opening the drawer doesn't accumulate
       # duplicate handlers bound to stale, detached inputs.
@@ -812,7 +822,7 @@ module.exports = do ->
         @cardSettingsWrap.find('.js-default-value-tab').removeClass('default-value-tab--hidden')
         $defaultPanel = $($viewTemplates.$$render('row.defaultValuePanel'))
         $defaultPanel.appendTo(@cardSettingsWrap.find('.js-card-settings-default-value'))
-        # OC fork (P1.3): AI Generate button in the Default Value panel header.
+        # OC fork (P1.1): AI Generate button in the Default Value panel header.
         generateButtonBridge.mountGenerateButton(
           $defaultPanel.find('.default-value-panel__header').get(0)
           { row: @model, attribute: 'default' }
@@ -836,7 +846,7 @@ module.exports = do ->
             evt.preventDefault()
             $defaultTextarea.blur()
 
-        # OC fork (P1.3): keep the visible field in sync when the AI dialog's
+        # OC fork (P1.1): keep the visible field in sync when the AI dialog's
         # Apply writes directly to the model — otherwise the textarea still
         # shows whatever it had at drawer-open time until the drawer is
         # closed/reopened. Guarded by a value comparison so the user's own
@@ -862,7 +872,7 @@ module.exports = do ->
         @cardSettingsWrap.find('.js-calculation-tab').removeClass('calculation-tab--hidden')
         $calcPanel = $($viewTemplates.$$render('row.calculationPanel'))
         $calcPanel.appendTo(@cardSettingsWrap.find('.js-card-settings-calculation'))
-        # OC fork (P1.3): AI Generate button in the Calculation panel header.
+        # OC fork (P1.1): AI Generate button in the Calculation panel header.
         generateButtonBridge.mountGenerateButton(
           $calcPanel.find('.calculation-panel__header').get(0)
           { row: @model, attribute: 'calculation' }
@@ -889,7 +899,7 @@ module.exports = do ->
             evt.preventDefault()
             $calcTextarea.blur()
 
-        # OC fork (P1.3): keep the visible field in sync when the AI dialog's
+        # OC fork (P1.1): keep the visible field in sync when the AI dialog's
         # Apply writes directly to the model — see matching comment above
         # refreshDefaultInput for the full rationale (guarded write, listenTo
         # + @stopListening() teardown in _cleanupExpandedRender).

--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -469,7 +469,11 @@ module.exports = do ->
       # live-refresh bindings) so re-opening the drawer doesn't accumulate
       # duplicate handlers bound to stale, detached inputs.
       @stopListening()
-      @$('.card__settings').detach()
+      # Detach THIS row's own drawer (the node captured at expand), not a fresh
+      # `.card__settings` query — on a group row that selector also matches nested
+      # child-row drawers and would detach them too (Copilot review). Falls back
+      # to the scoped query only if the capture is somehow missing.
+      (@cardSettingsWrap ? @$('.card__settings').eq(0)).detach()
 
     clone: (event) ->
       parent = @model._parent

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -605,6 +605,22 @@ module.exports = do ->
     html: -> false
     insertInDOM: (rowView)-> return
 
+  # OC fork (P1.1, PR#273 round-3): before rebuilding a skip-logic/validation
+  # facade (postInitialize), release the survey listeners its current state and
+  # criterion presenters registered — otherwise every rebuild leaks listeners
+  # bound to the replaced facade. Mirrors the existing cleanup idiom in
+  # mv.skipLogicHelpers: `use_mode_selector_helper`'s
+  # `survey.off null, null, @state` and criterion remove()'s
+  # `survey.off null, null, presenter`.
+  releaseFacadeSurveyListeners = (model) ->
+    survey = model?.getSurvey?()
+    state = model?.facade?.context?.state
+    return unless survey and state
+    survey.off(null, null, state)
+    if state.presenters
+      survey.off(null, null, presenter) for presenter in state.presenters
+    return
+
   viewRowDetail.DetailViewMixins.relevant =
     html: ->
       @$el.addClass("card__settings__fields--active")
@@ -648,6 +664,7 @@ module.exports = do ->
       # unrelated operation. Contain it (PR#273 #3).
       @rowView.listenTo(@model, 'change:value', =>
         try
+          releaseFacadeSurveyListeners(@model)
           @model.postInitialize()
           @model.facade.render(@target_element)
         catch e
@@ -691,6 +708,7 @@ module.exports = do ->
       # contain any throw (PR#273 #3).
       @rowView.listenTo(@model, 'change:value', =>
         try
+          releaseFacadeSurveyListeners(@model)
           @model.postInitialize()
           @model.facade.render(@target_element)
         catch e

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -614,7 +614,7 @@ module.exports = do ->
       """
 
     afterRender: ->
-      # OC fork (P1.3): .skiplogic__extras (holding the AI Generate button) is
+      # OC fork (P1.1): .skiplogic__extras (holding the AI Generate button) is
       # rendered ABOVE .skiplogic__main so the button sits at the top of the
       # panel, matching the other logic panels. It must NEVER be inside
       # .skiplogic__main — the facade calls .empty() on that node every mode switch.
@@ -642,9 +642,16 @@ module.exports = do ->
       # 'change', not model.set('value')), so this never fights the user's own
       # edits. Bound on the long-lived rowView so _cleanupExpandedRender's
       # stopListening tears it down (no duplicate handlers across drawer opens).
+      # change:value can also fire from undo/redo, paste, or a bulk import — not
+      # just the AI dialog's Apply — and Backbone dispatches it synchronously
+      # from .set(), so an uncaught throw here would propagate out of that
+      # unrelated operation. Contain it (PR#273 #3).
       @rowView.listenTo(@model, 'change:value', =>
-        @model.postInitialize()
-        @model.facade.render(@target_element)
+        try
+          @model.postInitialize()
+          @model.facade.render(@target_element)
+        catch e
+          console.error('Logic Builder: failed to refresh the relevant panel after a value change', e)
       )
 
     insertInDOM: (rowView) ->
@@ -658,7 +665,7 @@ module.exports = do ->
       </div>
       """
     afterRender: ->
-      # OC fork (P1.3): .skiplogic__extras (holding the AI Generate button) is
+      # OC fork (P1.1): .skiplogic__extras (holding the AI Generate button) is
       # rendered ABOVE .skiplogic__main so the button sits at the top of the
       # panel, matching the other logic panels. It must NEVER be inside
       # .skiplogic__main — the facade calls .empty() on that node every mode switch.
@@ -679,10 +686,15 @@ module.exports = do ->
 
       # OC fork (PR#273 #2): see the identical note on the relevant panel above.
       # The validation-criteria facade is likewise seeded once and cached, so
-      # rebuild + re-render it when the value changes underneath us.
+      # rebuild + re-render it when the value changes underneath us. Same
+      # non-Apply triggers and synchronous dispatch as the relevant panel, so
+      # contain any throw (PR#273 #3).
       @rowView.listenTo(@model, 'change:value', =>
-        @model.postInitialize()
-        @model.facade.render(@target_element)
+        try
+          @model.postInitialize()
+          @model.facade.render(@target_element)
+        catch e
+          console.error('Logic Builder: failed to refresh the constraint panel after a value change', e)
       )
 
     insertInDOM: (rowView) ->
@@ -935,12 +947,12 @@ module.exports = do ->
       modelValue = @model.getValue()
       if modelValue?
         @$input.val(modelValue)
-      # OC fork (P1.3): AI Generate button in the Repeat Count panel header.
+      # OC fork (P1.1): AI Generate button in the Repeat Count panel header.
       generateButtonBridge.mountGenerateButton(
         @$el.find('.repeat-count-panel__header').get(0)
         { row: @model._parent, attribute: 'repeat_count' }
       )
-      # OC fork (P1.3): keep the visible field in sync when the AI dialog's
+      # OC fork (P1.1): keep the visible field in sync when the AI dialog's
       # Apply writes directly to the model — otherwise the input still shows
       # whatever it had at drawer-open time until the drawer is
       # closed/reopened. Guarded by a value comparison so the user's own

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -633,6 +633,20 @@ module.exports = do ->
         { row: @model._parent, attribute: 'relevant' }
       )
 
+      # OC fork (PR#273 #2): the skip-logic facade is seeded from the model value
+      # once and cached, so an external write (e.g. applying an AI-generated
+      # expression) leaves the panel showing the old value and can silently
+      # overwrite the applied one. Rebuild the facade from the current value and
+      # re-render whenever value changes underneath us. change:value fires only
+      # on such external writes here (typing updates facade state + a survey
+      # 'change', not model.set('value')), so this never fights the user's own
+      # edits. Bound on the long-lived rowView so _cleanupExpandedRender's
+      # stopListening tears it down (no duplicate handlers across drawer opens).
+      @rowView.listenTo(@model, 'change:value', =>
+        @model.postInitialize()
+        @model.facade.render(@target_element)
+      )
+
     insertInDOM: (rowView) ->
       @_insertInDOM rowView.cardSettingsWrap.find('.js-card-settings-relevant-logic').eq(0)
 
@@ -661,6 +675,14 @@ module.exports = do ->
       generateButtonBridge.mountGenerateButton(
         @$('.skiplogic__extras').get(0)
         { row: @model._parent, attribute: 'constraint' }
+      )
+
+      # OC fork (PR#273 #2): see the identical note on the relevant panel above.
+      # The validation-criteria facade is likewise seeded once and cached, so
+      # rebuild + re-render it when the value changes underneath us.
+      @rowView.listenTo(@model, 'change:value', =>
+        @model.postInitialize()
+        @model.facade.render(@target_element)
       )
 
     insertInDOM: (rowView) ->

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -716,6 +716,13 @@ module.exports = do ->
         try
           releaseFacadeSurveyListeners(@model)
           @model.postInitialize()
+          # Re-capture the render anchor from the live DOM in case a helper ever
+          # replaces it again (round-7: the hand-code helper used to replaceWith()
+          # the anchor, so @target_element pointed at a detached node and every
+          # later refresh rendered offscreen). Falls back to the original capture
+          # when the query comes up empty.
+          liveTarget = @$('.skiplogic__main')
+          @target_element = liveTarget if liveTarget.length > 0
           @model.facade.render(@target_element)
         catch e
           console.error('Logic Builder: failed to refresh the constraint panel after a value change', e)

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -9,6 +9,7 @@ $hxl = require './view.rowDetail.hxlDict'
 $viewRowDetailSkipLogic = require './view.rowDetail.SkipLogic'
 $viewTemplates = require './view.templates'
 $rowTemplates = require './view.row.templates'
+generateButtonBridge = require '#/openclinica/generateButtonBridge'
 
 module.exports = do ->
   viewRowDetail = {}
@@ -613,15 +614,24 @@ module.exports = do ->
       """
 
     afterRender: ->
+      # OC fork (P1.3): .skiplogic__extras (holding the AI Generate button) is
+      # rendered ABOVE .skiplogic__main so the button sits at the top of the
+      # panel, matching the other logic panels. It must NEVER be inside
+      # .skiplogic__main — the facade calls .empty() on that node every mode switch.
       @$el.find(".relevant__editor").html("""
-        <div class="skiplogic__main"></div>
         <p class="skiplogic__extras">
         </p>
+        <div class="skiplogic__main"></div>
       """)
 
       @target_element = @$('.skiplogic__main')
 
       @model.facade.render @target_element
+
+      generateButtonBridge.mountGenerateButton(
+        @$('.skiplogic__extras').get(0)
+        { row: @model._parent, attribute: 'relevant' }
+      )
 
     insertInDOM: (rowView) ->
       @_insertInDOM rowView.cardSettingsWrap.find('.js-card-settings-relevant-logic').eq(0)
@@ -634,15 +644,24 @@ module.exports = do ->
       </div>
       """
     afterRender: ->
+      # OC fork (P1.3): .skiplogic__extras (holding the AI Generate button) is
+      # rendered ABOVE .skiplogic__main so the button sits at the top of the
+      # panel, matching the other logic panels. It must NEVER be inside
+      # .skiplogic__main — the facade calls .empty() on that node every mode switch.
       @$el.find(".constraint__editor").html("""
-        <div class="skiplogic__main"></div>
         <p class="skiplogic__extras">
         </p>
+        <div class="skiplogic__main"></div>
       """)
 
       @target_element = @$('.skiplogic__main')
 
       @model.facade.render @target_element
+
+      generateButtonBridge.mountGenerateButton(
+        @$('.skiplogic__extras').get(0)
+        { row: @model._parent, attribute: 'constraint' }
+      )
 
     insertInDOM: (rowView) ->
       @_insertInDOM rowView.cardSettingsWrap.find('.js-card-settings-validation-criteria')
@@ -894,6 +913,27 @@ module.exports = do ->
       modelValue = @model.getValue()
       if modelValue?
         @$input.val(modelValue)
+      # OC fork (P1.3): AI Generate button in the Repeat Count panel header.
+      generateButtonBridge.mountGenerateButton(
+        @$el.find('.repeat-count-panel__header').get(0)
+        { row: @model._parent, attribute: 'repeat_count' }
+      )
+      # OC fork (P1.3): keep the visible field in sync when the AI dialog's
+      # Apply writes directly to the model — otherwise the input still shows
+      # whatever it had at drawer-open time until the drawer is
+      # closed/reopened. Guarded by a value comparison so the user's own
+      # typing (which already wrote this exact value via fireChange above)
+      # never re-triggers a redundant DOM write. This DetailView instance is
+      # recreated on every drawer open, so the listener is registered on the
+      # long-lived @rowView (via listenTo) rather than on this instance —
+      # @rowView's @stopListening() in _cleanupExpandedRender (view.row.coffee)
+      # tears it down on close, instead of accumulating a new handler each
+      # time the drawer reopens.
+      refreshRepeatCountInput = =>
+        modelVal = @model.get('value') or ''
+        if @$input.val() isnt modelVal
+          @$input.val(modelVal)
+      @rowView.listenTo(@model, 'change:value', refreshRepeatCountInput)
 
   # handled by mandatorySettingSelector
   viewRowDetail.DetailViewMixins.required =

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mantine/form": "^7.16.2",
         "@mantine/hooks": "^7.15.0",
         "@mapbox/leaflet-omnivore": "^0.3.4",
+        "@openclinica/logic-builder": "file:../logic-builder",
         "@placemarkio/check-geojson": "^0.1.14",
         "@sentry/react": "^7.120.3",
         "@tanstack/react-query": "^5.85.5",
@@ -215,6 +216,28 @@
       },
       "engines": {
         "node": "^20.18.1 || ^22.4.1"
+      }
+    },
+    "../logic-builder": {
+      "name": "@openclinica/logic-builder",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^12.1.5",
+        "@types/react": "^16.14.0",
+        "@types/react-dom": "^16.9.0",
+        "jsdom": "^20.0.0",
+        "react": "16.13.1",
+        "react-dom": "16.13.1",
+        "sass": "^1.57.0",
+        "typescript": "~5.3.3",
+        "vite": "^4.5.0",
+        "vite-plugin-dts": "^3.6.0",
+        "vitest": "^0.34.0"
+      },
+      "peerDependencies": {
+        "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4932,6 +4955,10 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
+    },
+    "node_modules/@openclinica/logic-builder": {
+      "resolved": "../logic-builder",
+      "link": true
     },
     "node_modules/@orval/angular": {
       "version": "7.10.0",
@@ -33929,6 +33956,23 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
+    },
+    "@openclinica/logic-builder": {
+      "version": "file:../logic-builder",
+      "requires": {
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^12.1.5",
+        "@types/react": "^16.14.0",
+        "@types/react-dom": "^16.9.0",
+        "jsdom": "^20.0.0",
+        "react": "16.13.1",
+        "react-dom": "16.13.1",
+        "sass": "^1.57.0",
+        "typescript": "~5.3.3",
+        "vite": "^4.5.0",
+        "vite-plugin-dts": "^3.6.0",
+        "vitest": "^0.34.0"
+      }
     },
     "@orval/angular": {
       "version": "7.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@mantine/form": "^7.16.2",
         "@mantine/hooks": "^7.15.0",
         "@mapbox/leaflet-omnivore": "^0.3.4",
-        "@openclinica/logic-builder": "github:OpenClinica/logic-builder#8faa854e888458256f0c682cb3330980ec17d02e",
         "@placemarkio/check-geojson": "^0.1.14",
         "@sentry/react": "^7.120.3",
         "@tanstack/react-query": "^5.85.5",
@@ -216,6 +215,9 @@
       },
       "engines": {
         "node": "^20.18.1 || ^22.4.1"
+      },
+      "optionalDependencies": {
+        "@openclinica/logic-builder": "github:OpenClinica/logic-builder#8faa854e888458256f0c682cb3330980ec17d02e"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4938,6 +4940,7 @@
       "version": "0.1.0",
       "resolved": "git+ssh://git@github.com/OpenClinica/logic-builder.git#8faa854e888458256f0c682cb3330980ec17d02e",
       "integrity": "sha512-HLbTflNqt4stMzezeRo6URkfbl02RFgO/zgU+a3hbe4AYeU9nchVUc5BeVlIhGB69TDQ2n7sRX+1vkxzn+W9gQ==",
+      "optional": true,
       "peerDependencies": {
         "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
@@ -33944,6 +33947,7 @@
       "version": "git+ssh://git@github.com/OpenClinica/logic-builder.git#8faa854e888458256f0c682cb3330980ec17d02e",
       "integrity": "sha512-HLbTflNqt4stMzezeRo6URkfbl02RFgO/zgU+a3hbe4AYeU9nchVUc5BeVlIhGB69TDQ2n7sRX+1vkxzn+W9gQ==",
       "from": "@openclinica/logic-builder@github:OpenClinica/logic-builder#8faa854e888458256f0c682cb3330980ec17d02e",
+      "optional": true,
       "requires": {}
     },
     "@orval/angular": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mantine/form": "^7.16.2",
         "@mantine/hooks": "^7.15.0",
         "@mapbox/leaflet-omnivore": "^0.3.4",
-        "@openclinica/logic-builder": "file:../logic-builder",
+        "@openclinica/logic-builder": "github:OpenClinica/logic-builder#8faa854e888458256f0c682cb3330980ec17d02e",
         "@placemarkio/check-geojson": "^0.1.14",
         "@sentry/react": "^7.120.3",
         "@tanstack/react-query": "^5.85.5",
@@ -216,28 +216,6 @@
       },
       "engines": {
         "node": "^20.18.1 || ^22.4.1"
-      }
-    },
-    "../logic-builder": {
-      "name": "@openclinica/logic-builder",
-      "version": "0.1.0",
-      "devDependencies": {
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^12.1.5",
-        "@types/react": "^16.14.0",
-        "@types/react-dom": "^16.9.0",
-        "jsdom": "^20.0.0",
-        "react": "16.13.1",
-        "react-dom": "16.13.1",
-        "sass": "^1.57.0",
-        "typescript": "~5.3.3",
-        "vite": "^4.5.0",
-        "vite-plugin-dts": "^3.6.0",
-        "vitest": "^0.34.0"
-      },
-      "peerDependencies": {
-        "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4957,8 +4935,13 @@
       "dev": true
     },
     "node_modules/@openclinica/logic-builder": {
-      "resolved": "../logic-builder",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/OpenClinica/logic-builder.git#8faa854e888458256f0c682cb3330980ec17d02e",
+      "integrity": "sha512-HLbTflNqt4stMzezeRo6URkfbl02RFgO/zgU+a3hbe4AYeU9nchVUc5BeVlIhGB69TDQ2n7sRX+1vkxzn+W9gQ==",
+      "peerDependencies": {
+        "react": "^16.13.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.13.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@orval/angular": {
       "version": "7.10.0",
@@ -33958,21 +33941,10 @@
       "dev": true
     },
     "@openclinica/logic-builder": {
-      "version": "file:../logic-builder",
-      "requires": {
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^12.1.5",
-        "@types/react": "^16.14.0",
-        "@types/react-dom": "^16.9.0",
-        "jsdom": "^20.0.0",
-        "react": "16.13.1",
-        "react-dom": "16.13.1",
-        "sass": "^1.57.0",
-        "typescript": "~5.3.3",
-        "vite": "^4.5.0",
-        "vite-plugin-dts": "^3.6.0",
-        "vitest": "^0.34.0"
-      }
+      "version": "git+ssh://git@github.com/OpenClinica/logic-builder.git#8faa854e888458256f0c682cb3330980ec17d02e",
+      "integrity": "sha512-HLbTflNqt4stMzezeRo6URkfbl02RFgO/zgU+a3hbe4AYeU9nchVUc5BeVlIhGB69TDQ2n7sRX+1vkxzn+W9gQ==",
+      "from": "@openclinica/logic-builder@github:OpenClinica/logic-builder#8faa854e888458256f0c682cb3330980ec17d02e",
+      "requires": {}
     },
     "@orval/angular": {
       "version": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^4.5.8",
-    "@openclinica/logic-builder": "file:../logic-builder",
     "@fontsource/roboto-mono": "^4.4.2",
     "@mantine/core": "^7.15.0",
     "@mantine/form": "^7.16.2",
     "@mantine/hooks": "^7.15.0",
     "@mapbox/leaflet-omnivore": "^0.3.4",
+    "@openclinica/logic-builder": "github:OpenClinica/logic-builder#8faa854e888458256f0c682cb3330980ec17d02e",
     "@placemarkio/check-geojson": "^0.1.14",
     "@sentry/react": "^7.120.3",
     "@tanstack/react-query": "^5.85.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@mantine/form": "^7.16.2",
     "@mantine/hooks": "^7.15.0",
     "@mapbox/leaflet-omnivore": "^0.3.4",
-    "@openclinica/logic-builder": "github:OpenClinica/logic-builder#8faa854e888458256f0c682cb3330980ec17d02e",
     "@placemarkio/check-geojson": "^0.1.14",
     "@sentry/react": "^7.120.3",
     "@tanstack/react-query": "^5.85.5",
@@ -267,5 +266,8 @@
     "workerDirectory": [
       "msw-mocks"
     ]
+  },
+  "optionalDependencies": {
+    "@openclinica/logic-builder": "github:OpenClinica/logic-builder#8faa854e888458256f0c682cb3330980ec17d02e"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^4.5.8",
+    "@openclinica/logic-builder": "file:../logic-builder",
     "@fontsource/roboto-mono": "^4.4.2",
     "@mantine/core": "^7.15.0",
     "@mantine/form": "^7.16.2",

--- a/test/xlform/validationCriteria.tests.coffee
+++ b/test/xlform/validationCriteria.tests.coffee
@@ -294,3 +294,58 @@ do ->
     it 'creates an EmptyOperator for "empty" type', ->
       op = factory.create_operator('empty', null, 0)
       expect(op instanceof $skipLogic.EmptyOperator).toBe(true)
+
+  ###############################################################
+  # OC fork (PR#273 round-7): the hand-code helper must render INTO the panel's
+  # anchor (.skiplogic__main), not replaceWith() it — replacing detaches the
+  # node the constraint DetailView re-renders into on every change:value, so
+  # every later refresh lands in a detached subtree, and the hand-code input
+  # ends up outside the .skiplogic__main scope the post-Apply focus lookup uses.
+  ###############################################################
+  describe 'validationCriteria: ValidationLogicHandCodeHelper.render()', ->
+
+    $ = require('jquery')
+    $validationLogicHelpers = require('../../jsapp/xlform/src/mv.validationLogicHelpers')
+
+    makeWidget = ->
+      w = {}
+      w.render = -> w
+      w.attach_to = -> w
+      w.bind_event = -> w
+      w.val = -> ''
+      w
+    makeHelper = (criteria) ->
+      view_factory =
+        create_textarea: -> makeWidget()
+        create_button: -> makeWidget()
+        survey: { trigger: -> }
+      context =
+        helper_factory: { current_question: { cid: 'q1' } }
+        view_factory: { survey: { trigger: -> } }
+        use_mode_selector_helper: ->
+      new $validationLogicHelpers.ValidationLogicHandCodeHelper(criteria, null, view_factory, context)
+
+    it 'renders into the destination, keeping the anchor alive with the input inside it', ->
+      $container = $('<div class="skiplogic__main"></div>').appendTo(document.body)
+      makeHelper('. >= 18').render($container)
+      # The anchor must survive the render (change:value refreshes render into
+      # this same node)…
+      expect(document.body.contains($container.get(0))).toBe(true)
+      # …and the hand-code input must be INSIDE it, where the post-Apply focus
+      # selector (.skiplogic__main input) can find it.
+      expect($container.find('#q1-handcode').length).toBe(1)
+      $container.remove()
+      return
+
+    it 'supports the context render cycle: empty + re-render into the same anchor', ->
+      $container = $('<div class="skiplogic__main"></div>').appendTo(document.body)
+      makeHelper('. >= 18').render($container)
+      # The helper context empties the destination before each render (mode
+      # switches, change:value rebuilds) — a fresh helper must render into the
+      # SAME still-attached node.
+      $container.empty()
+      makeHelper('. < 5').render($container)
+      expect(document.body.contains($container.get(0))).toBe(true)
+      expect($container.find('#q1-handcode').val()).toBe('. < 5')
+      $container.remove()
+      return

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,15 @@
     "paths": {
       "#/*": ["./jsapp/js/*"],
       "js/*": ["./jsapp/js/*"], // for scss files only.
-      "scss/*": ["./jsapp/scss/*"] // for scss files only.
+      "scss/*": ["./jsapp/scss/*"], // for scss files only.
+      // OC fork: @openclinica/logic-builder is a private optionalDependency.
+      // Resolve the real package when installed (local dev, Jenkins/prod image);
+      // fall back to the committed CI stub when it's absent (public CI). Tried
+      // in order, first match wins.
+      "@openclinica/logic-builder": [
+        "./node_modules/@openclinica/logic-builder",
+        "./jsapp/js/openclinica/logic-builder-stub"
+      ]
     },
     "target": "es2017",
     "module": "es2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,13 @@
       "@openclinica/logic-builder": [
         "./node_modules/@openclinica/logic-builder",
         "./jsapp/js/openclinica/logic-builder-stub"
+      ],
+      // Side-effect CSS import in generateButtonBridge.tsx; same real-first,
+      // stub-fallback so the eslint import resolver finds it when the package
+      // is absent (public CI).
+      "@openclinica/logic-builder/style.css": [
+        "./node_modules/@openclinica/logic-builder/dist/style.css",
+        "./jsapp/js/openclinica/logic-builder-stub/style.css"
       ]
     },
     "target": "es2017",

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -97,7 +97,7 @@ const commonOptions = {
       '#': path.join(__dirname, '..', 'jsapp', 'js'), // TODO: someday rename "js" to "src".
       js: path.join(__dirname, '..', 'jsapp', 'js'), // within scss files only, sass-loader doesn't handle # char.
       scss: path.join(__dirname, '..', 'jsapp', 'scss'), // within scss files only.
-      // OC fork: dedupe React so the symlinked `@openclinica/logic-builder`
+      // OC fork: dedupe React so the git-pinned `@openclinica/logic-builder`
       // (which externalizes react/react-dom) binds to kpi's single React 18
       // copy instead of its own dev-dependency React.
       react: path.join(__dirname, '../node_modules/react'),

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -97,6 +97,11 @@ const commonOptions = {
       '#': path.join(__dirname, '..', 'jsapp', 'js'), // TODO: someday rename "js" to "src".
       js: path.join(__dirname, '..', 'jsapp', 'js'), // within scss files only, sass-loader doesn't handle # char.
       scss: path.join(__dirname, '..', 'jsapp', 'scss'), // within scss files only.
+      // OC fork: dedupe React so the symlinked `@openclinica/logic-builder`
+      // (which externalizes react/react-dom) binds to kpi's single React 18
+      // copy instead of its own dev-dependency React.
+      react: path.join(__dirname, '../node_modules/react'),
+      'react-dom': path.join(__dirname, '../node_modules/react-dom'),
     },
     // HACKFIX: needed because of https://github.com/react-dnd/react-dnd/issues/3423
     fallback: {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -9,6 +9,24 @@ const outputPath = path.resolve(__dirname, '../jsapp/compiled/')
 // ExtractTranslationKeysPlugin, for one, just fails if this directory doesn't exist
 fs.mkdirSync(outputPath, { recursive: true })
 
+// OC fork: @openclinica/logic-builder is a private optionalDependency. Use the
+// real package wherever it's installed (local dev, Jenkins/prod image); fall
+// back to the committed CI stub only when it's absent (public CI, which can't
+// clone the private repo). Aliasing the bare specifier (with `$` for an exact
+// match) and the side-effect `/style.css` covers both imports.
+const logicBuilderAlias = (() => {
+  try {
+    require.resolve('@openclinica/logic-builder/package.json')
+    return {} // installed → normal node_modules resolution (respects its exports)
+  } catch {
+    const stub = path.join(__dirname, '..', 'jsapp', 'js', 'openclinica', 'logic-builder-stub')
+    return {
+      '@openclinica/logic-builder$': path.join(stub, 'index.tsx'),
+      '@openclinica/logic-builder/style.css': path.join(stub, 'style.css'),
+    }
+  }
+})()
+
 // HACK: we needed to define this postcss-loader because of a problem with
 // including CSS files from node_modules directory, i.e. this build error:
 // `Error: No PostCSS Config found in: /srv/node_modules/…`
@@ -102,6 +120,7 @@ const commonOptions = {
       // copy instead of its own dev-dependency React.
       react: path.join(__dirname, '../node_modules/react'),
       'react-dom': path.join(__dirname, '../node_modules/react-dom'),
+      ...logicBuilderAlias,
     },
     // HACKFIX: needed because of https://github.com/react-dnd/react-dnd/issues/3423
     fallback: {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -16,9 +16,16 @@ fs.mkdirSync(outputPath, { recursive: true })
 // match) and the side-effect `/style.css` covers both imports.
 const logicBuilderAlias = (() => {
   try {
-    require.resolve('@openclinica/logic-builder/package.json')
+    // Probe the BARE specifier: it resolves through the package's `exports` map
+    // (which only exposes `.` and `./style.css`) to dist/, so it proves the
+    // package is installed AND built. Probing `<pkg>/package.json` throws
+    // ERR_PACKAGE_PATH_NOT_EXPORTED even when installed (round-7: that made
+    // every build silently bundle the stub).
+    require.resolve('@openclinica/logic-builder')
+    console.log('[logic-builder] bundling the real @openclinica/logic-builder package')
     return {} // installed → normal node_modules resolution (respects its exports)
   } catch {
+    console.log('[logic-builder] private package absent — bundling the CI stub')
     const stub = path.join(__dirname, '..', 'jsapp', 'js', 'openclinica', 'logic-builder-stub')
     return {
       '@openclinica/logic-builder$': path.join(stub, 'index.tsx'),


### PR DESCRIPTION
## What
Wires the `@openclinica/logic-builder` **P1.1** Generate button + AI Generator dialog into the Form Designer (Backbone/xlform):
- Mounts a `GenerateButton` into each applicable logic panel (Calculation, Default, Constraint, Required, Relevant, Repeat Count) via a small React-in-Backbone bridge (`jsapp/js/openclinica/`), with root tracking + unmount on drawer teardown.
- Renders one shared `<AiGeneratorDialog>` in `EditableForm.tsx`, opened via the `surveyState` store; Apply writes the expression to the xlform model (`row.get(col).set('value', …)` + `trigger('change')`) and persists through the normal Save.
- React/react-dom dedupe alias in webpack so the externalized package binds to the host React.

## ⚠️ Draft — not mergeable as-is
- Depends on the companion **OC-28246** PR in `OpenClinica/logic-builder`. The package is wired as a local `file:../logic-builder` dependency; repoint to the published/git ref once that lands.
- Generation uses a **stub** client (canned expressions); the real `generate-expression` endpoint is a later story.

## Testing
Frontend builds (`npm run build:app`); the full flow (Generate button in each panel → dialog opens above the form → generate → Apply fills the field) verified live in a running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

