### PR TITLE
OC-28196: Translate form content in the Translations Table

### DIFF
--- a/jsapp/js/components/bigModal/bigModal.js
+++ b/jsapp/js/components/bigModal/bigModal.js
@@ -174,8 +174,8 @@ class BigModal extends React.Component {
 
       case MODAL_TYPES.FORM_TRANSLATIONS_TABLE:
         this.setState({
-          title: t('Translations Table'),
-          modalClass: 'modal--large',
+          title: `${t('Translations table')} — ${this.props.params.langString}`,
+          modalClass: 'modal--form-translations-table modal--oc',
         })
         break
 

--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -333,6 +333,55 @@ $modal-custom-header-height: 60px;
   }
 }
 
+.modal.modal--form-translations-table {
+  // Wide enough to keep the 3-column table readable, but not full-viewport
+  // like `.modal--large` (which this modal intentionally doesn't use).
+  // `max-height` (not `height`) lets the modal shrink to fit a form with only
+  // a few translatable strings, while still capping growth and scrolling
+  // internally for forms with many.
+  width: 100%;
+  max-width: 900px;
+  max-height: 85vh;
+
+  .modal__content {
+    max-height: 85vh;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .modal__body {
+    flex: 1 1 auto;
+    // Without this, a flex child won't shrink below its content's natural
+    // size, so the body would just push the modal taller instead of
+    // scrolling internally once `max-height` is reached.
+    min-height: 0;
+    overflow: auto;
+  }
+}
+
+.modal__footer--translation-table {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-align: left;
+
+  // The base `.modal__footer` clearfix (`::before`/`::after { content: '' }`,
+  // for its old float-based button layout) becomes an invisible first/last
+  // flex item once this footer is `display: flex`, offsetting the Save
+  // button from the table's left edge by one `gap` unit. Flex containers
+  // don't need a float clearfix, so drop the generated content entirely.
+  &::before,
+  &::after {
+    content: none;
+  }
+
+  .translation-table-footer__help {
+    font-size: 12px;
+    color: colors.$kobo-gray-600;
+  }
+}
+
 .enketo-holder {
   // resets modal window paddings
   margin: 0 -20px;
@@ -562,6 +611,11 @@ $modal-custom-header-height: 60px;
   .translation-table-container {
     flex: 1;
     overflow-y: auto;
+    // Columns use explicit fixed widths (see translationTable.js) sized to
+    // fit without horizontal scroll; this is a safety net so a stray few px
+    // of overflow never produces a second, horizontal scrollbar alongside
+    // the vertical one above.
+    overflow-x: hidden;
     border: 1px solid colors.$kobo-gray-300;
   }
 
@@ -602,15 +656,10 @@ $modal-custom-header-height: 60px;
         }
       }
 
-      > .rt-th:first-child,
-      > .rt-td:first-child {
-        min-width: 30%;
+      // "Original string" (2nd column: Element, Original string, Translation)
+      > .rt-th:nth-child(2),
+      > .rt-td:nth-child(2) {
         color: colors.$kobo-gray-700;
-      }
-
-      > .rt-th:last-child,
-      > .rt-td:last-child {
-        min-width: 70%;
       }
 
       .translation {

--- a/jsapp/js/components/formBuilder/formBuilderUtils.tests.js
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.tests.js
@@ -1,4 +1,5 @@
 import {
+  mergeFreshTranslations,
   nullifyTranslations,
   readParameters,
   unnullifyTranslations,
@@ -407,5 +408,139 @@ describe('writeParameters', () => {
     it(`should return ${pair.note}`, () => {
       chai.expect(writeParameters(pair.obj)).to.equal(pair.str)
     })
+  })
+})
+
+describe('mergeFreshTranslations', () => {
+  // Returns the parsed survey after merging.
+  const merge = (surveyData, freshContent, protectedLangName) =>
+    JSON.parse(mergeFreshTranslations(JSON.stringify(surveyData), freshContent, protectedLangName))
+
+  it("1. updates a $kuid-matched row's non-protected-language translation from fresh content", () => {
+    const result = merge(
+      {
+        survey: [
+          { $kuid: 'q1', name: 'q1', type: 'text', 'label::English (en)': 'Hello', 'label::Polski (pl)': 'STALE' },
+        ],
+      },
+      {
+        translated: ['label'],
+        translations: ['English (en)', 'Polski (pl)'],
+        survey: [{ $kuid: 'q1', name: 'q1', label: ['Hello', 'Cześć'] }],
+      },
+      'English (en)',
+    )
+    expect(result.survey[0]['label::English (en)']).to.equal('Hello') // protected, untouched
+    expect(result.survey[0]['label::Polski (pl)']).to.equal('Cześć') // updated
+  })
+
+  it('2. falls back to name matching when the row has no $kuid', () => {
+    const result = merge(
+      { survey: [{ name: 'q1', type: 'text', 'label::English (en)': 'Hello', 'label::Polski (pl)': 'STALE' }] },
+      {
+        translated: ['label'],
+        translations: ['English (en)', 'Polski (pl)'],
+        survey: [{ $kuid: 'q1', name: 'q1', label: ['Hello', 'Cześć'] }],
+      },
+      'English (en)',
+    )
+    expect(result.survey[0]['label::Polski (pl)']).to.equal('Cześć')
+  })
+
+  it('3. never touches the protected language key even when fresh content differs there', () => {
+    const result = merge(
+      { survey: [{ name: 'q1', 'label::English (en)': 'IN PROGRESS EDIT', 'label::Polski (pl)': 'old' }] },
+      {
+        translated: ['label'],
+        translations: ['English (en)', 'Polski (pl)'],
+        survey: [{ name: 'q1', label: ['Different English', 'Nowy'] }],
+      },
+      'English (en)',
+    )
+    expect(result.survey[0]['label::English (en)']).to.equal('IN PROGRESS EDIT') // protected suffixed key preserved
+    expect(result.survey[0]['label::Polski (pl)']).to.equal('Nowy')
+  })
+
+  it('4. leaves no phantom key for a language removed from fresh translations', () => {
+    const result = merge(
+      {
+        survey: [
+          { name: 'q1', 'label::English (en)': 'Hello', 'label::Polski (pl)': 'Cześć', 'label::Deutsch (de)': 'Hallo' },
+        ],
+      },
+      {
+        translated: ['label'],
+        translations: ['English (en)', 'Polski (pl)'], // Deutsch removed
+        survey: [{ name: 'q1', label: ['Hello', 'Cześć'] }],
+      },
+      'English (en)',
+    )
+    expect(result.survey[0]).to.not.have.property('label::Deutsch (de)')
+    expect(result.survey[0]['label::Polski (pl)']).to.equal('Cześć')
+  })
+
+  it('5. creates a new key for a language added to fresh translations', () => {
+    const result = merge(
+      { survey: [{ name: 'q1', 'label::English (en)': 'Hello', 'label::Polski (pl)': 'Cześć' }] },
+      {
+        translated: ['label'],
+        translations: ['English (en)', 'Polski (pl)', 'Deutsch (de)'], // Deutsch added
+        survey: [{ name: 'q1', label: ['Hello', 'Cześć', 'Hallo'] }],
+      },
+      'English (en)',
+    )
+    expect(result.survey[0]['label::Deutsch (de)']).to.equal('Hallo')
+  })
+
+  it('6. leaves a row present in surveyData but absent from fresh content completely untouched', () => {
+    const result = merge(
+      {
+        survey: [
+          { name: 'q1', 'label::English (en)': 'Hello', 'label::Polski (pl)': 'Cześć' },
+          { name: 'q2', 'label::English (en)': 'New Q', 'label::Polski (pl)': 'unsaved' }, // newly added, unsaved
+        ],
+      },
+      {
+        translated: ['label'],
+        translations: ['English (en)', 'Polski (pl)'],
+        survey: [{ name: 'q1', label: ['Hello', 'Zmienione'] }],
+      },
+      'English (en)',
+    )
+    expect(result.survey[1]['label::English (en)']).to.equal('New Q')
+    expect(result.survey[1]['label::Polski (pl)']).to.equal('unsaved') // untouched
+  })
+
+  it('7. updates a choice matched by name + list_name (no $kuid)', () => {
+    const result = merge(
+      { choices: [{ name: 'yes', list_name: 'yn', 'label::English (en)': 'Yes', 'label::Polski (pl)': 'STALE' }] },
+      {
+        translated: ['label'],
+        translations: ['English (en)', 'Polski (pl)'],
+        choices: [{ name: 'yes', list_name: 'yn', label: ['Yes', 'Tak'] }],
+      },
+      'English (en)',
+    )
+    expect(result.choices[0]['label::Polski (pl)']).to.equal('Tak')
+    expect(result.choices[0]['label::English (en)']).to.equal('Yes')
+  })
+
+  it('8. resolves langNames[0] from translations_0 when translations[0] is null', () => {
+    // protectedLangName is null here so the index-0 write is observable: if the
+    // translations_0 fallback works, the value lands under `label::English (en)`
+    // (suffixed); if it failed, it would land under the bare `label` key.
+    const result = merge(
+      { survey: [{ name: 'q1' }] },
+      {
+        translated: ['label'],
+        translations: [null, 'Polski (pl)'],
+        translations_0: 'English (en)',
+        survey: [{ name: 'q1', label: ['Hello', 'Cześć'] }],
+      },
+      null,
+    )
+    expect(result.survey[0]['label::English (en)']).to.equal('Hello')
+    expect(result.survey[0]['label::Polski (pl)']).to.equal('Cześć')
+    expect(result.survey[0]).to.not.have.property('label')
   })
 })

--- a/jsapp/js/components/formBuilder/formBuilderUtils.tests.js
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.tests.js
@@ -1,7 +1,9 @@
 import {
+  applyFreshPrimaryLanguage,
   mergeFreshTranslations,
   nullifyTranslations,
   readParameters,
+  resolveCurrentPrimaryLanguage,
   unnullifyTranslations,
   writeParameters,
 } from '#/components/formBuilder/formBuilderUtils'
@@ -542,5 +544,57 @@ describe('mergeFreshTranslations', () => {
     expect(result.survey[0]['label::English (en)']).to.equal('Hello')
     expect(result.survey[0]['label::Polski (pl)']).to.equal('Cześć')
     expect(result.survey[0]).to.not.have.property('label')
+  })
+})
+
+describe('resolveCurrentPrimaryLanguage', () => {
+  it('1. prefers the fresh asset primary language over the frozen mount snapshot', () => {
+    const result = resolveCurrentPrimaryLanguage(
+      { translations: ['French (fr)', 'English (en)'], translated: ['label'] },
+      { translations_0: 'English (en)', translated: ['label', 'hint'] },
+    )
+    expect(result.primaryLangName).to.equal('French (fr)')
+    expect(result.translatedProps).to.deep.equal(['label'])
+  })
+
+  it('2. falls back to translations_0 when fresh translations[0] is null', () => {
+    const result = resolveCurrentPrimaryLanguage(
+      { translations: [null, 'Polski (pl)'], translations_0: 'English (en)', translated: ['label'] },
+      undefined,
+    )
+    expect(result.primaryLangName).to.equal('English (en)')
+  })
+
+  it('3. falls back to the frozen mount snapshot when there is no fresh content', () => {
+    const result = resolveCurrentPrimaryLanguage(undefined, { translations_0: 'English (en)', translated: ['label'] })
+    expect(result.primaryLangName).to.equal('English (en)')
+    expect(result.translatedProps).to.deep.equal(['label'])
+  })
+
+  it('4. returns null and an empty list when neither source has a primary language', () => {
+    const result = resolveCurrentPrimaryLanguage(undefined, undefined)
+    expect(result.primaryLangName).to.equal(null)
+    expect(result.translatedProps).to.deep.equal([])
+  })
+})
+
+describe('applyFreshPrimaryLanguage', () => {
+  it('1. unnullifies the survey JSON when a primary language is found', () => {
+    const surveyDataJSON = JSON.stringify({ settings: [{}], survey: [{ name: 'q1', label: 'Hello' }] })
+    const result = applyFreshPrimaryLanguage(
+      surveyDataJSON,
+      { translations: ['English (en)'], translated: ['label'] },
+      undefined,
+    )
+    expect(result.primaryLangName).to.equal('English (en)')
+    const survey = JSON.parse(result.surveyDataJSON)
+    expect(survey.survey[0]['label::English (en)']).to.equal('Hello')
+  })
+
+  it('2. leaves the survey JSON untouched when no primary language is found', () => {
+    const surveyDataJSON = JSON.stringify({ settings: [{}], survey: [{ name: 'q1', label: 'Hello' }] })
+    const result = applyFreshPrimaryLanguage(surveyDataJSON, undefined, undefined)
+    expect(result.primaryLangName).to.equal(null)
+    expect(result.surveyDataJSON).to.equal(surveyDataJSON)
   })
 })

--- a/jsapp/js/components/formBuilder/formBuilderUtils.ts
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.ts
@@ -85,6 +85,70 @@ export function unnullifyTranslations(surveyDataJSON: string, surveyInitialParam
   return JSON.stringify(surveyData)
 }
 
+export function mergeFreshTranslations(
+  surveyDataJSON: string,
+  freshContent: AssetContent,
+  protectedLangName: string | null,
+): string {
+  if (!freshContent?.translations || !freshContent.translated) {
+    return surveyDataJSON
+  }
+  const surveyData: FlatSurvey = JSON.parse(surveyDataJSON)
+  const translatedProps = freshContent.translated
+
+  const langNames: Array<string | null> = freshContent.translations.map((name, i) =>
+    i === 0 ? (name ?? freshContent.translations_0 ?? null) : name,
+  )
+
+  const applyItem = (flat: Record<string, unknown>, fresh: Record<string, unknown>) => {
+    translatedProps.forEach((prop) => {
+      // Delete every existing key for this prop, EXCEPT the protected language's key.
+      Object.keys(flat).forEach((k) => {
+        if (k !== prop && !k.startsWith(`${prop}::`)) return
+        const keyLangName = k === prop ? null : k.slice(prop.length + 2)
+        if (protectedLangName !== null && keyLangName === protectedLangName) return
+        delete flat[k]
+      })
+      const freshValues = fresh[prop] as Array<string | null> | undefined
+      if (!freshValues) return
+      langNames.forEach((langName, i) => {
+        if (protectedLangName !== null && langName === protectedLangName) return
+        const key = langName == null ? prop : `${prop}::${langName}`
+        flat[key] = freshValues[i] ?? null
+      })
+    })
+  }
+
+  const rowsByKuid = new Map<string, any>()
+  const rowsByName = new Map<string, any>()
+  freshContent.survey?.forEach((r: any) => {
+    if (r.$kuid) rowsByKuid.set(r.$kuid, r)
+    const nm = r.name || r.$autoname
+    if (nm) rowsByName.set(nm, r)
+  })
+  const choicesByKuid = new Map<string, any>()
+  const choicesByNameList = new Map<string, any>()
+  freshContent.choices?.forEach((c: any) => {
+    if (c.$kuid) choicesByKuid.set(c.$kuid, c)
+    const nm = c.name || c.$autovalue
+    if (nm) choicesByNameList.set(`${nm}::${c.list_name}`, c)
+  })
+
+  surveyData.survey?.forEach((row: any) => {
+    const rowName = row.name || row.$autoname
+    const fresh = (row.$kuid && rowsByKuid.get(row.$kuid)) || (rowName && rowsByName.get(rowName))
+    if (fresh) applyItem(row, fresh)
+  })
+  surveyData.choices?.forEach((ch: any) => {
+    const chName = ch.name || ch.$autovalue
+    const fresh =
+      (ch.$kuid && choicesByKuid.get(ch.$kuid)) || (chName && choicesByNameList.get(`${chName}::${ch.list_name}`))
+    if (fresh) applyItem(ch, fresh)
+  })
+
+  return JSON.stringify(surveyData)
+}
+
 /**
  * @typedef NullifiedTranslations
  * @property {object} survey - Modified survey.

--- a/jsapp/js/components/formBuilder/formBuilderUtils.ts
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.ts
@@ -150,6 +150,51 @@ export function mergeFreshTranslations(
 }
 
 /**
+ * Resolves the form's current primary-language name and translated-property
+ * list, preferring a freshly-fetched asset's actual current state over the
+ * Form Builder survey model's frozen mount-time snapshot (`_initialParams`,
+ * captured once when the model was built and never updated afterward — see
+ * EditableForm.tsx's previewForm()/saveForm(), which both need this and
+ * previously duplicated the same fallback logic inline in two places).
+ */
+export function resolveCurrentPrimaryLanguage(
+  freshContent: AssetContent | undefined,
+  frozenInitialParams: AssetContent | undefined,
+): { primaryLangName: string | null; translatedProps: string[] } {
+  // `translations[0]` is normally the real primary-language name, but
+  // (mirroring mergeFreshTranslations() above) it can be `null` with the name
+  // stored in `translations_0` instead.
+  const primaryLangName =
+    freshContent?.translations?.[0] ?? freshContent?.translations_0 ?? frozenInitialParams?.translations_0 ?? null
+  const translatedProps = freshContent?.translated ?? frozenInitialParams?.translated ?? []
+  return { primaryLangName, translatedProps }
+}
+
+/**
+ * Resolves the current primary language (see resolveCurrentPrimaryLanguage())
+ * and, if one exists, unnullifies `surveyDataJSON` against it. Bundles the
+ * two steps together since every caller needs both and previously duplicated
+ * this same pairing inline in two places (Form Designer's previewForm() and
+ * saveForm()).
+ */
+export function applyFreshPrimaryLanguage(
+  surveyDataJSON: string,
+  freshContent: AssetContent | undefined,
+  frozenInitialParams: AssetContent | undefined,
+): { surveyDataJSON: string; primaryLangName: string | null } {
+  const { primaryLangName, translatedProps } = resolveCurrentPrimaryLanguage(freshContent, frozenInitialParams)
+  if (!primaryLangName) {
+    return { surveyDataJSON, primaryLangName }
+  }
+  const updatedSurveyDataJSON = unnullifyTranslations(surveyDataJSON, {
+    ...frozenInitialParams,
+    translations_0: primaryLangName,
+    translated: translatedProps,
+  })
+  return { surveyDataJSON: updatedSurveyDataJSON, primaryLangName }
+}
+
+/**
  * @typedef NullifiedTranslations
  * @property {object} survey - Modified survey.
  * @property {Array<string|null>} translations - Modified translations.

--- a/jsapp/js/components/modalForms/TranslationSettings.tsx
+++ b/jsapp/js/components/modalForms/TranslationSettings.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import alertify from 'alertifyjs'
 import cloneDeep from 'lodash.clonedeep'
 import { actions } from '#/actions'
+import { invalidateItem } from '#/api/mutation-defaults/common'
+import { getAssetsRetrieveQueryKey } from '#/api/react-query/manage-projects-and-library-content'
 import assetStore, { type AssetStoreData } from '#/assetStore'
 import bem from '#/bem'
 import Button from '#/components/common/button'
@@ -269,6 +271,11 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
       { content: JSON.stringify(content) },
       // reload asset on failure
       {
+        onComplete: () => {
+          // Keep the React Query asset cache in sync so Form Designer's live
+          // preview/save reads the freshly-saved translations.
+          invalidateItem(getAssetsRetrieveQueryKey(this.state.asset.uid))
+        },
         onFailed: () => {
           actions.resources.loadAsset({ id: this.state.asset.uid }, true)
           notify.error('failed to update translations')

--- a/jsapp/js/components/modalForms/translationTable.js
+++ b/jsapp/js/components/modalForms/translationTable.js
@@ -4,6 +4,8 @@ import alertify from 'alertifyjs'
 import ReactTable from 'react-table'
 import TextareaAutosize from 'react-textarea-autosize'
 import { actions } from '#/actions'
+import { invalidateItem } from '#/api/mutation-defaults/common'
+import { getAssetsRetrieveQueryKey } from '#/api/react-query/manage-projects-and-library-content'
 import bem from '#/bem'
 import Button from '#/components/common/button'
 import LoadingSpinner from '#/components/common/loadingSpinner'
@@ -183,7 +185,12 @@ export class TranslationTable extends React.Component {
         content: JSON.stringify(content),
       },
       {
-        onComplete: this.markFormIdle.bind(this),
+        onComplete: () => {
+          this.markFormIdle()
+          // Keep the React Query asset cache in sync so Form Designer's live
+          // preview/save reads the freshly-saved translations.
+          invalidateItem(getAssetsRetrieveQueryKey(this.props.asset.uid))
+        },
         onFailed: this.markFormUnsaved.bind(this),
       },
     )
@@ -232,6 +239,11 @@ export class TranslationTable extends React.Component {
       { content: JSON.stringify(content) },
       // reload asset on failure
       {
+        onComplete: () => {
+          // Keep the React Query asset cache in sync so Form Designer's live
+          // preview/save reads the freshly-saved translations.
+          invalidateItem(getAssetsRetrieveQueryKey(this.props.asset.uid))
+        },
         onFailed: () => {
           actions.resources.loadAsset({ id: this.props.asset.uid }, true)
           notify.error('failed to update translations')

--- a/jsapp/js/components/modalForms/translationTable.js
+++ b/jsapp/js/components/modalForms/translationTable.js
@@ -10,17 +10,47 @@ import bem from '#/bem'
 import Button from '#/components/common/button'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import { LockingRestrictionName } from '#/components/locking/lockingConstants'
-import { hasAssetRestriction, hasRowRestriction } from '#/components/locking/lockingUtils'
-import LanguageForm from '#/components/modalForms/languageForm'
+import { hasRowRestriction } from '#/components/locking/lockingUtils'
 import { GROUP_TYPES_BEGIN, MODAL_TYPES, QUESTION_TYPES } from '#/constants'
 import pageState from '#/pageState.store'
 import { stores } from '#/stores'
-import { getLangString, notify, recordKeys } from '#/utils'
+import { recordKeys } from '#/utils'
 
 const SAVE_BUTTON_TEXT = {
-  DEFAULT: t('Save Changes'),
-  UNSAVED: t('* Save Changes'),
+  DEFAULT: t('Save translations'),
+  UNSAVED: t('* Save translations'),
   PENDING: t('Saving…'),
+}
+
+const ELEMENT_TYPE_LABELS = {
+  hint: t('Hint'),
+  constraint_message: t('Constraint message'),
+  required_message: t('Required message'),
+  guidance_hint: t('Guidance hint'),
+  'media::image': t('Image'),
+  'media::audio': t('Audio'),
+  'media::video': t('Video'),
+}
+
+// Derives a human-readable "Element" column label (e.g. "Group label",
+// "Question label", "Choice label", "Hint") from the translatable property
+// name and, for survey rows, the row's type. Falls back to a humanized
+// version of the property name for any translatable column pyxform may
+// produce that isn't explicitly mapped above.
+function getElementTypeLabel(contentProp, itemProp, rowType) {
+  if (contentProp === 'choices') {
+    return t('Choice label')
+  }
+  if (itemProp === 'label') {
+    return rowType && GROUP_TYPES_BEGIN[rowType] ? t('Group label') : t('Question label')
+  }
+  if (ELEMENT_TYPE_LABELS[itemProp]) {
+    return ELEMENT_TYPE_LABELS[itemProp]
+  }
+  return itemProp
+    .replace(/^media::/, '')
+    .replace(/_/g, ' ')
+    .replace(/^\w/, (c) => c.toUpperCase())
 }
 
 export class TranslationTable extends React.Component {
@@ -30,13 +60,10 @@ export class TranslationTable extends React.Component {
       saveChangesButtonText: SAVE_BUTTON_TEXT.DEFAULT,
       isSaveChangesButtonPending: false,
       tableData: [],
-      showLanguageForm: false,
-      langString: props.langString,
     }
     stores.translations.setTranslationTableUnsaved(false)
     const { translated, survey, choices, translations } = props.asset.content
     const langIndex = props.langIndex
-    const editableColTitle = langIndex == 0 ? t('updated text') : t('translation')
     const lockedChoiceLists = []
 
     // add each translatable property for survey items to translation table
@@ -61,6 +88,7 @@ export class TranslationTable extends React.Component {
             name: row.name || row.$autoname,
             itemProp: property,
             contentProp: 'survey',
+            elementType: getElementTypeLabel('survey', property, row.type),
             isLabelLocked: isLabelLocked,
           })
         }
@@ -79,6 +107,7 @@ export class TranslationTable extends React.Component {
             listName: choice.list_name,
             itemProp: 'label',
             contentProp: 'choices',
+            elementType: getElementTypeLabel('choices', 'label'),
             isLabelLocked: isLabelLocked,
           })
         }
@@ -87,9 +116,14 @@ export class TranslationTable extends React.Component {
 
     this.columns = [
       {
+        Header: t('Element'),
+        accessor: 'elementType',
+        width: 150,
+      },
+      {
         Header: t('Original string'),
         accessor: 'original',
-        minWidth: 130,
+        width: 353,
         Cell: (cellInfo) => (
           // Disabling has no effect on this cell, but we do it to gray out the
           // text to indicate that the label is locked
@@ -101,18 +135,7 @@ export class TranslationTable extends React.Component {
         ),
       },
       {
-        Header: () => (
-          <React.Fragment>
-            <Button
-              type='text'
-              size='m'
-              onClick={this.toggleRenameLanguageForm.bind(this)}
-              isDisabled={!this.canEditLanguages()}
-              startIcon={this.state.showLanguageForm ? 'close' : 'edit'}
-            />
-            {`${translations[langIndex]} ${editableColTitle}`}
-          </React.Fragment>
-        ),
+        Header: translations[langIndex],
         accessor: 'translation',
         className: 'translation',
         Cell: (cellInfo) => (
@@ -154,11 +177,6 @@ export class TranslationTable extends React.Component {
       isSaveChangesButtonPending: false,
     })
     stores.translations.setTranslationTableUnsaved(false)
-  }
-
-  toggleRenameLanguageForm(evt) {
-    evt.stopPropagation()
-    this.setState({ showLanguageForm: !this.state.showLanguageForm })
   }
 
   saveChanges() {
@@ -219,43 +237,6 @@ export class TranslationTable extends React.Component {
     })
   }
 
-  onLanguageChange(lang, index) {
-    const content = this.props.asset.content,
-      langString = getLangString(lang)
-
-    content.translations[index] = langString
-    this.setState({ langString: langString })
-
-    if (index === 0) {
-      content.settings.default_language = langString
-    }
-
-    this.updateHeader(content)
-  }
-
-  updateHeader(content) {
-    actions.resources.updateAsset(
-      this.props.asset.uid,
-      { content: JSON.stringify(content) },
-      // reload asset on failure
-      {
-        onComplete: () => {
-          // Keep the React Query asset cache in sync so Form Designer's live
-          // preview/save reads the freshly-saved translations.
-          invalidateItem(getAssetsRetrieveQueryKey(this.props.asset.uid))
-        },
-        onFailed: () => {
-          actions.resources.loadAsset({ id: this.props.asset.uid }, true)
-          notify.error('failed to update translations')
-        },
-      },
-    )
-  }
-
-  getAllLanguages() {
-    return this.props.asset.content.translations
-  }
-
   // Compare current row type agaisnt those with lockable labels and return if
   // the relevant label restriction applies
   isRowLabelLocked(rowType, rowName) {
@@ -272,30 +253,9 @@ export class TranslationTable extends React.Component {
     return hasRowRestriction(this.props.asset.content, rowName, LockingRestrictionName.choice_label_edit)
   }
 
-  canEditLanguages() {
-    return (
-      this.props.asset?.content && !hasAssetRestriction(this.props.asset.content, LockingRestrictionName.language_edit)
-    )
-  }
-
   render() {
     return (
       <bem.FormModal m='translation-table'>
-        {this.state.showLanguageForm && (
-          <bem.FormModal>
-            <bem.FormModal__item>
-              <bem.FormView__cell m='update-language-form'>
-                <LanguageForm
-                  langString={this.state.langString}
-                  langIndex={this.props.langIndex}
-                  onLanguageChange={this.onLanguageChange.bind(this)}
-                  existingLanguages={this.getAllLanguages()}
-                  isDefault={this.props.langIndex === 0}
-                />
-              </bem.FormView__cell>
-            </bem.FormModal__item>
-          </bem.FormModal>
-        )}
         <div className='translation-table-container'>
           <ReactTable
             data={this.state.tableData}
@@ -313,9 +273,7 @@ export class TranslationTable extends React.Component {
           />
         </div>
 
-        <bem.Modal__footer>
-          <Button type='secondary' size='l' onClick={this.onBack.bind(this)} label={t('Back')} />
-
+        <bem.Modal__footer m='translation-table'>
           <Button
             type='primary'
             size='l'
@@ -323,6 +281,12 @@ export class TranslationTable extends React.Component {
             isDisabled={this.state.isSaveChangesButtonPending}
             label={this.state.saveChangesButtonText}
           />
+
+          <Button type='secondary' size='l' onClick={this.onBack.bind(this)} label={t('Cancel')} />
+
+          <span className='translation-table-footer__help'>
+            {t('Saving adds the translations to the form definition.')}
+          </span>
         </bem.Modal__footer>
       </bem.FormModal>
     )

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -475,8 +475,32 @@ export default function EditableForm(props: EditableFormProps) {
     }
 
     let surveyJSON = surveyToValidJson(app?.survey)
-    if (app?.survey._initialParams?.translations_0) {
-      surveyJSON = unnullifyTranslations(surveyJSON, app.survey._initialParams)
+
+    // Fetch the current saved asset up front, rather than gating unnullify/
+    // merge on the live model's frozen mount-time primary-language snapshot
+    // (`app.survey._initialParams`, set once in the Survey constructor and
+    // never updated — see model.survey.coffee). A primary language set for
+    // the first time in this session would otherwise never be picked up,
+    // since `_initialParams.translations_0` stays permanently unset for any
+    // form that had no primary language when Form Designer first loaded.
+    let freshAsset: AssetResponse | undefined
+    if (assetUid !== '') {
+      try {
+        freshAsset = await dataInterface.getAsset({ id: assetUid })
+      } catch {
+        // Fresh fetch failed — fall back to the live model's own (possibly
+        // stale or language-blind) translations rather than blocking preview.
+      }
+    }
+    const primaryLangName = freshAsset?.content?.translations?.[0] ?? app?.survey._initialParams?.translations_0 ?? null
+    const translatedProps = freshAsset?.content?.translated ?? app?.survey._initialParams?.translated ?? []
+
+    if (primaryLangName) {
+      surveyJSON = unnullifyTranslations(surveyJSON, {
+        ...app?.survey._initialParams,
+        translations_0: primaryLangName,
+        translated: translatedProps,
+      })
     }
     let params: KoboMatrixParserParams & {
       asset?: string
@@ -487,19 +511,16 @@ export default function EditableForm(props: EditableFormProps) {
       params.asset = state.asset.url
     }
 
-    if (assetUid !== '' && app.survey._initialParams?.translations_0) {
-      try {
-        const freshAsset = await dataInterface.getAsset({ id: assetUid })
-        surveyJSON = mergeFreshTranslations(
-          surveyJSON,
-          freshAsset.content,
-          app.survey._initialParams?.translations_0 ?? null,
-        )
-        params.source = surveyJSON
-      } catch {
-        // Fresh fetch failed — fall back to previewing with the live model's
-        // own (possibly stale) translations rather than blocking preview entirely.
-      }
+    if (freshAsset?.content && primaryLangName) {
+      // Only protect the primary language from the merge when there's an
+      // actual unsaved local edit pending in this session (`needsSave()`).
+      // Without that, the common case — translate the primary language via
+      // Translations Table, then Preview without having touched anything
+      // inline — would keep showing the stale primary-language text for no
+      // reason, since there's nothing local left to protect.
+      const protectedLangName = needsSave() ? primaryLangName : null
+      surveyJSON = mergeFreshTranslations(surveyJSON, freshAsset.content, protectedLangName)
+      params.source = surveyJSON
     }
 
     params = koboMatrixParser(params)
@@ -586,8 +607,50 @@ export default function EditableForm(props: EditableFormProps) {
     if (surveyJSONWithMatrix) {
       surveyJSON = surveyJSONWithMatrix
     }
-    if (app.survey._initialParams?.translations_0) {
-      surveyJSON = unnullifyTranslations(surveyJSON, app.survey._initialParams)
+
+    // Fetch the current saved asset up front, rather than gating unnullify/
+    // merge on the live model's frozen mount-time primary-language snapshot
+    // (`app.survey._initialParams`, set once in the Survey constructor and
+    // never updated — see model.survey.coffee, and the same comment in
+    // previewForm()). Only relevant once the asset actually exists server-side.
+    let freshAsset: AssetResponse | undefined
+    let freshFetchFailed = false
+    if (assetUid !== '') {
+      try {
+        freshAsset = await dataInterface.getAsset({ id: assetUid })
+      } catch {
+        freshFetchFailed = true
+      }
+    }
+
+    // If the live model has never known about a primary language this
+    // session (i.e. one was set for the first time via Manage Languages,
+    // after this page loaded) AND we couldn't confirm the asset's actual
+    // current language state from the server, saving now would silently
+    // overwrite (delete) any language(s) added this session — abort rather
+    // than risk it.
+    if (assetUid !== '' && !app.survey._initialParams?.translations_0 && freshFetchFailed) {
+      alertify.defaults.theme.ok = 'ajs-cancel'
+      const dialog = alertify.dialog('alert')
+      dialog
+        .set({
+          title: t('Error saving form'),
+          message: t("Could not verify the form's current languages before saving. Please try again."),
+          label: t('Dismiss'),
+        })
+        .show()
+      return
+    }
+
+    const primaryLangName = freshAsset?.content?.translations?.[0] ?? app.survey._initialParams?.translations_0 ?? null
+    const translatedProps = freshAsset?.content?.translated ?? app.survey._initialParams?.translated ?? []
+
+    if (primaryLangName) {
+      surveyJSON = unnullifyTranslations(surveyJSON, {
+        ...app.survey._initialParams,
+        translations_0: primaryLangName,
+        translated: translatedProps,
+      })
     }
     // We normally have `content` as an actual object, not a stringified representation, but since
     // `actions.resources.updateAsset` already works with JSON string, let's extend the types
@@ -626,18 +689,15 @@ export default function EditableForm(props: EditableFormProps) {
         asset_updated: update_states.PENDING_UPDATE,
       }))
 
-      if (app.survey._initialParams?.translations_0) {
-        try {
-          const freshAsset = await dataInterface.getAsset({ id: assetUid })
-          params.content = mergeFreshTranslations(
-            params.content,
-            freshAsset.content,
-            app.survey._initialParams?.translations_0 ?? null,
-          )
-        } catch {
-          // Fresh fetch failed — fall back to saving with the live model's own
-          // translations rather than blocking the save entirely.
-        }
+      if (freshAsset?.content && primaryLangName) {
+        // Only protect the primary language when there was an actual unsaved
+        // local edit pending before this save started (`needsSave()`, read
+        // here before it flips to PENDING_UPDATE above — the `state` this
+        // closure captured at render time doesn't change until next
+        // render, so this still reads the pre-save value). See the same
+        // comment in previewForm() for why this matters.
+        const protectedLangName = needsSave() ? primaryLangName : null
+        params.content = mergeFreshTranslations(params.content, freshAsset.content, protectedLangName)
       }
 
       // TODO: change this into react-query mutation

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -25,6 +25,7 @@ import {
   type KoboMatrixParserParams,
   getFormBuilderAssetType,
   koboMatrixParser,
+  mergeFreshTranslations,
   surveyToValidJson,
   unnullifyTranslations,
 } from '#/components/formBuilder/formBuilderUtils'
@@ -454,7 +455,7 @@ export default function EditableForm(props: EditableFormProps) {
     return state.asset_updated === update_states.UNSAVED_CHANGES
   }
 
-  function previewForm(evt: React.TouchEvent<HTMLButtonElement>) {
+  async function previewForm(evt: React.TouchEvent<HTMLButtonElement>) {
     // At this point app should really be defined, and if not, there is no point in doing anything
     if (!app) {
       console.error('app is not defined!')
@@ -482,11 +483,26 @@ export default function EditableForm(props: EditableFormProps) {
       use_study_designer_preview?: boolean
     } = { source: surveyJSON, use_study_designer_preview: true }
 
-    params = koboMatrixParser(params)
-
     if (state.asset && state.asset.url) {
       params.asset = state.asset.url
     }
+
+    if (assetUid !== '') {
+      try {
+        const freshAsset = await dataInterface.getAsset({ id: assetUid })
+        surveyJSON = mergeFreshTranslations(
+          surveyJSON,
+          freshAsset.content,
+          app.survey._initialParams?.translations_0 ?? null,
+        )
+        params.source = surveyJSON
+      } catch {
+        // Fresh fetch failed — fall back to previewing with the live model's
+        // own (possibly stale) translations rather than blocking preview entirely.
+      }
+    }
+
+    params = koboMatrixParser(params)
 
     dataInterface
       .createAssetSnapshot(params)
@@ -510,7 +526,7 @@ export default function EditableForm(props: EditableFormProps) {
       })
   }
 
-  function saveForm(evt: React.TouchEvent<HTMLButtonElement>) {
+  async function saveForm(evt: React.TouchEvent<HTMLButtonElement>) {
     if (evt && evt.preventDefault) {
       evt.preventDefault()
     }
@@ -582,6 +598,10 @@ export default function EditableForm(props: EditableFormProps) {
     }
 
     if (state.isNewAsset) {
+      setState((currentState) => ({
+        ...currentState,
+        asset_updated: update_states.PENDING_UPDATE,
+      }))
       // we're intentionally leaving after creating new asset,
       // so there is nothing unsaved here
       unpreventClosingTab()
@@ -601,6 +621,23 @@ export default function EditableForm(props: EditableFormProps) {
         props.router.navigate(ROUTES.LIBRARY)
       })
     } else if (assetUid !== '') {
+      setState((currentState) => ({
+        ...currentState,
+        asset_updated: update_states.PENDING_UPDATE,
+      }))
+
+      try {
+        const freshAsset = await dataInterface.getAsset({ id: assetUid })
+        params.content = mergeFreshTranslations(
+          params.content,
+          freshAsset.content,
+          app.survey._initialParams?.translations_0 ?? null,
+        )
+      } catch {
+        // Fresh fetch failed — fall back to saving with the live model's own
+        // translations rather than blocking the save entirely.
+      }
+
       // TODO: change this into react-query mutation
       actions.resources.updateAsset
         .triggerAsync(assetUid, params)
@@ -639,10 +676,6 @@ export default function EditableForm(props: EditableFormProps) {
           }))
         })
     }
-    setState((currentState) => ({
-      ...currentState,
-      asset_updated: update_states.PENDING_UPDATE,
-    }))
   }
 
   function buttonStates() {

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -23,11 +23,11 @@ import TextBox from '#/components/common/textBox'
 import { isEConsentSignatureRow } from '#/components/formBuilder/econsentSignature'
 import {
   type KoboMatrixParserParams,
+  applyFreshPrimaryLanguage,
   getFormBuilderAssetType,
   koboMatrixParser,
   mergeFreshTranslations,
   surveyToValidJson,
-  unnullifyTranslations,
 } from '#/components/formBuilder/formBuilderUtils'
 import FormLockedMessage from '#/components/locking/formLockedMessage'
 import { LOCKING_UI_CLASSNAMES, LockingRestrictionName } from '#/components/locking/lockingConstants'
@@ -455,6 +455,26 @@ export default function EditableForm(props: EditableFormProps) {
     return state.asset_updated === update_states.UNSAVED_CHANGES
   }
 
+  /**
+   * Fetches the asset's current saved state, used by previewForm()/saveForm()
+   * to resolve the form's actual current primary language and translations
+   * instead of the live model's frozen mount-time snapshot (see the comment
+   * on `applyFreshPrimaryLanguage` usage in both functions for why).
+   */
+  async function fetchFreshAsset(
+    uid: string,
+  ): Promise<{ freshAsset: AssetResponse | undefined; fetchFailed: boolean }> {
+    if (uid === '') {
+      return { freshAsset: undefined, fetchFailed: false }
+    }
+    try {
+      const freshAsset = await dataInterface.getAsset({ id: uid })
+      return { freshAsset, fetchFailed: false }
+    } catch {
+      return { freshAsset: undefined, fetchFailed: true }
+    }
+  }
+
   async function previewForm(evt: React.TouchEvent<HTMLButtonElement>) {
     // At this point app should really be defined, and if not, there is no point in doing anything
     if (!app) {
@@ -483,25 +503,13 @@ export default function EditableForm(props: EditableFormProps) {
     // the first time in this session would otherwise never be picked up,
     // since `_initialParams.translations_0` stays permanently unset for any
     // form that had no primary language when Form Designer first loaded.
-    let freshAsset: AssetResponse | undefined
-    if (assetUid !== '') {
-      try {
-        freshAsset = await dataInterface.getAsset({ id: assetUid })
-      } catch {
-        // Fresh fetch failed — fall back to the live model's own (possibly
-        // stale or language-blind) translations rather than blocking preview.
-      }
-    }
-    const primaryLangName = freshAsset?.content?.translations?.[0] ?? app?.survey._initialParams?.translations_0 ?? null
-    const translatedProps = freshAsset?.content?.translated ?? app?.survey._initialParams?.translated ?? []
+    // A failed fetch just falls back to the live model's own (possibly stale
+    // or language-blind) translations rather than blocking preview.
+    const { freshAsset } = await fetchFreshAsset(assetUid)
+    const primaryLangResult = applyFreshPrimaryLanguage(surveyJSON, freshAsset?.content, app?.survey._initialParams)
+    surveyJSON = primaryLangResult.surveyDataJSON
+    const primaryLangName = primaryLangResult.primaryLangName
 
-    if (primaryLangName) {
-      surveyJSON = unnullifyTranslations(surveyJSON, {
-        ...app?.survey._initialParams,
-        translations_0: primaryLangName,
-        translated: translatedProps,
-      })
-    }
     let params: KoboMatrixParserParams & {
       asset?: string
       use_study_designer_preview?: boolean
@@ -613,15 +621,7 @@ export default function EditableForm(props: EditableFormProps) {
     // (`app.survey._initialParams`, set once in the Survey constructor and
     // never updated — see model.survey.coffee, and the same comment in
     // previewForm()). Only relevant once the asset actually exists server-side.
-    let freshAsset: AssetResponse | undefined
-    let freshFetchFailed = false
-    if (assetUid !== '') {
-      try {
-        freshAsset = await dataInterface.getAsset({ id: assetUid })
-      } catch {
-        freshFetchFailed = true
-      }
-    }
+    const { freshAsset, fetchFailed: freshFetchFailed } = await fetchFreshAsset(assetUid)
 
     // If the live model has never known about a primary language this
     // session (i.e. one was set for the first time via Manage Languages,
@@ -642,16 +642,10 @@ export default function EditableForm(props: EditableFormProps) {
       return
     }
 
-    const primaryLangName = freshAsset?.content?.translations?.[0] ?? app.survey._initialParams?.translations_0 ?? null
-    const translatedProps = freshAsset?.content?.translated ?? app.survey._initialParams?.translated ?? []
+    const primaryLangResult = applyFreshPrimaryLanguage(surveyJSON, freshAsset?.content, app.survey._initialParams)
+    surveyJSON = primaryLangResult.surveyDataJSON
+    const primaryLangName = primaryLangResult.primaryLangName
 
-    if (primaryLangName) {
-      surveyJSON = unnullifyTranslations(surveyJSON, {
-        ...app.survey._initialParams,
-        translations_0: primaryLangName,
-        translated: translatedProps,
-      })
-    }
     // We normally have `content` as an actual object, not a stringified representation, but since
     // `actions.resources.updateAsset` already works with JSON string, let's extend the types
     const params: Partial<AssetRequestObject> & { content: string } = { content: surveyJSON }

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -487,7 +487,7 @@ export default function EditableForm(props: EditableFormProps) {
       params.asset = state.asset.url
     }
 
-    if (assetUid !== '') {
+    if (assetUid !== '' && app.survey._initialParams?.translations_0) {
       try {
         const freshAsset = await dataInterface.getAsset({ id: assetUid })
         surveyJSON = mergeFreshTranslations(
@@ -626,16 +626,18 @@ export default function EditableForm(props: EditableFormProps) {
         asset_updated: update_states.PENDING_UPDATE,
       }))
 
-      try {
-        const freshAsset = await dataInterface.getAsset({ id: assetUid })
-        params.content = mergeFreshTranslations(
-          params.content,
-          freshAsset.content,
-          app.survey._initialParams?.translations_0 ?? null,
-        )
-      } catch {
-        // Fresh fetch failed — fall back to saving with the live model's own
-        // translations rather than blocking the save entirely.
+      if (app.survey._initialParams?.translations_0) {
+        try {
+          const freshAsset = await dataInterface.getAsset({ id: assetUid })
+          params.content = mergeFreshTranslations(
+            params.content,
+            freshAsset.content,
+            app.survey._initialParams?.translations_0 ?? null,
+          )
+        } catch {
+          // Fresh fetch failed — fall back to saving with the live model's own
+          // translations rather than blocking the save entirely.
+        }
       }
 
       // TODO: change this into react-query mutation


### PR DESCRIPTION
## Summary
- Adds per-language Translations Table (opened from Manage Languages): lists every translatable element (question/group labels, hints, choice labels, validation messages) beside its original-language string, editable and pre-filled on reopen
- Fixes the core bug behind why saved translations didn't reliably show up: Form Designer's live in-memory survey model is built once at page load and never re-syncs with the server, so translations added via the Translations Table (which only patch the server-side asset) were invisible to Preview and Save for the rest of that session
- Adds `mergeFreshTranslations()` to reconcile freshly-saved translations into the live model before preview/save, and fixes the specific case where a primary language is set for the first time in the same session (the merge gate was keyed off a mount-time snapshot that never updates, so a first-time primary language — and anything added after it — was silently dropped from preview, and could be wiped out entirely if "Save Draft" was clicked)
- Restyles the Translations Table and Manage Languages/Collection dialogs to match the design mockup

## Jira tickets resolved
- [OC-28196](https://openclinica-team.atlassian.net/browse/OC-28196) — Translate form content in the Translations Table (AC1–AC5)
- [OC-28200](https://openclinica-team.atlassian.net/browse/OC-28200) — Preview the form in each language (AC1–AC3): the merge fix in this PR is what makes translations authored via the Translations Table actually appear in the Enketo preview's language dropdown

## Test plan
- [x] `npm run lint:types` — no new errors
- [x] `npx biome check` — no errors
- [x] `npm run test:unit` — all passing, including new `mergeFreshTranslations()` test cases
- [x] Manually verified in a running local OC4 stack, single continuous Form Designer session (no reload): create form → set primary language for the first time → add another language → translate it → Preview shows correct language dropdown and translated text
- [x] Manually verified the same scenario with "Save Draft" instead of Preview — added language's translations persist correctly, not silently dropped
- [x] Regression-checked an existing form that already had multiple languages configured — preview/save still work as before