### PR TITLE
OC-28234 Move "Item width" to standalone section between Appearance a…

### DIFF
--- a/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
@@ -265,7 +265,7 @@
 // Item width standalone section (between Appearance and Advanced options)
 // ==========================================================================
 
-.item-width-subsection {
+.item-width-section {
   padding: 6px 0 4px;
   border-bottom: 1px solid #CBD5E1;
   margin-bottom: 12px;

--- a/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_appearance.scss
@@ -262,22 +262,22 @@
 }
 
 // ==========================================================================
-// Item width sub-section (inside Advanced options)
+// Item width standalone section (between Appearance and Advanced options)
 // ==========================================================================
 
 .item-width-subsection {
   padding: 6px 0 4px;
   border-bottom: 1px solid #CBD5E1;
-  margin-bottom: 4px;
+  margin-bottom: 12px;
 }
 
 .item-width__header {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
-  color: #334155;
+  color: #020617;
   padding: 2px 0;
   cursor: pointer;
   user-select: none;
@@ -300,7 +300,7 @@
 
 .item-width__title {
   text-align: left;
-  color: #334155;
+  color: #020617;
 }
 
 .item-width__pill {

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_settings.scss
@@ -343,7 +343,7 @@
   row-gap: 12px;
   align-items: start;
 
-  .item-width-subsection { grid-column: 1 / -1; }
+  .item-width-section { grid-column: 1 / -1; }
   .xlf-dv-default       { grid-column: 1; }
   .xlf-dv-readonly      { grid-column: 1; }
   .xlf-dv-oc_item_group { grid-column: 2; }

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1514,7 +1514,7 @@ module.exports = do ->
       selectedW  = if outOfRange then null else if currentW? then currentW else defaultW
 
       # --- Build DOM ---
-      $wrap = $('<div/>', { class: 'js-item-width-wrap item-width-subsection', style: 'grid-column: 1 / -1' })
+      $wrap = $('<div/>', { class: 'js-item-width-wrap item-width-section', style: 'grid-column: 1 / -1' })
 
       # Header row (collapse toggle)
       $header = $('<button/>', {

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1478,11 +1478,10 @@ module.exports = do ->
 
     _afterRenderWidth: ->
       return unless @is_form_style_theme_grid()
-      $advBody = @rowView.cardSettingsWrap.find('#js-card-settings-row-options-advanced').eq(0)
-      return unless $advBody.length
+      return unless @rowView.cardSettingsWrap.find('.js-card-settings-advanced-toggle').length
 
-      # Idempotent: remove stale sub-section from a prior render
-      $advBody.find('.js-item-width-wrap').remove()
+      # Idempotent: remove stale section from a prior render
+      @rowView.cardSettingsWrap.find('.js-item-width-wrap').remove()
 
       groupCols = getParentGroupCols(@)
       groupName = getParentGroupName(@)
@@ -1523,7 +1522,7 @@ module.exports = do ->
         type: 'button'
         'aria-expanded': 'false'
       })
-      $header.append($('<span/>', { class: 'item-width__title' }).text(t('Item width in group grid')))
+      $header.append($('<span/>', { class: 'item-width__title' }).text(t('Item width')))
       $pill = $('<span/>', { class: 'js-item-width-pill item-width__pill', style: 'display:none' })
       $header.append($pill)
       $chev = $('<i/>', { class: 'k-icon k-icon-angle-down item-width__chev', 'aria-hidden': 'true' })
@@ -1571,7 +1570,8 @@ module.exports = do ->
 
       $body.hide()
       $wrap.append($body)
-      $advBody.prepend($wrap)
+      $advancedToggle = @rowView.cardSettingsWrap.find('.js-card-settings-advanced-toggle').eq(0)
+      $wrap.insertBefore($advancedToggle)
 
       @_refreshWidthPill($pill)
       $pill.show()


### PR DESCRIPTION
…nd Advanced options

### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Moves the "Item width" section from being nested inside Advanced options to its own standalone section positioned between Appearance and Advanced options, as required by OC-28006 AC1. Also renames the section header from "Item width in group grid" to "Item width" and updates its font size and color to match the Appearance section style.

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
