### PR TITLE
OC-28306 Preserve out-of-range group/item width instead of destroying it

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1049,12 +1049,37 @@ module.exports = do ->
 
   WIDTH_OPTIONS = ("w#{n}" for n in [1..10])
 
-  getWidthFromModelValue = (modelValue) ->
+  # Raw stored width token, any magnitude (e.g. "w14"). Used wherever the
+  # actual saved value must be preserved or displayed, since a value outside
+  # w1-w10 is still real data and must never be treated as "unset".
+  # Highest-numbered token wins when more than one is present. Tokens with a
+  # leading zero (e.g. "w01") are deliberately NOT matched — WIDTH_OPTIONS
+  # only ever produces canonical forms ("w1".."w10"), so a leading-zero
+  # variant would otherwise be preserved here as "in range" (e.g. "w01"
+  # parses to 1) while getWidthFromModelValue's exact-string check treats it
+  # as unsupported, an inconsistency between the two readers.
+  getWidthTokenFromModelValue = (modelValue) ->
     return null unless modelValue?
-    found = null
-    for w in WIDTH_OPTIONS
-      found = w if new RegExp("\\b#{w}\\b").test(modelValue)
-    found
+    best = null
+    bestN = -1
+    re = /\bw([1-9]\d*)\b/g
+    while (m = re.exec(modelValue))
+      n = parseInt(m[1], 10)
+      if n > bestN
+        bestN = n
+        best = m[0]
+    best
+
+  # Supported picker option only (w1-w10) — null for both "unset" and "stored
+  # but unsupported" (e.g. "w14"). Only safe for call sites that hand the
+  # result to something that can only represent w1-w10, such as
+  # @$select_width or the fixed-size card grids.
+  # Note: picks the highest RAW token first, then range-checks it — it does
+  # not fall back to the highest in-range token. A malformed mixed value
+  # like "w3 w14" is null here (unsupported), not "w3" as it was previously.
+  getWidthFromModelValue = (modelValue) ->
+    token = getWidthTokenFromModelValue(modelValue)
+    if token? and token in WIDTH_OPTIONS then token else null
 
   getParentGroupCols = (mixin) ->
     parent_group = mixin.model_get_parent_group()
@@ -1175,6 +1200,9 @@ module.exports = do ->
     get_width_from_model_value: ->
       getWidthFromModelValue(@model.get('value'))
 
+    get_width_token_from_model_value: ->
+      getWidthTokenFromModelValue(@model.get('value'))
+
     afterRender: ->
       if @isCardGridType()
         @_afterRenderCardGrid()
@@ -1241,7 +1269,7 @@ module.exports = do ->
 
       # For groups: Columns in Grid as own section after Appearance; for non-groups: item width picker
       if questionType is 'group'
-        @_afterRenderGroupCols(@get_width_from_model_value())
+        @_afterRenderGroupCols(@get_width_token_from_model_value())
       else
         @_afterRenderWidth()
 
@@ -1329,7 +1357,12 @@ module.exports = do ->
       value = buildModelValue(@_card, @_columnCount, @_customText)
       if @is_form_style_theme_grid()
         width_val = @$select_width.val()
-        if width_val and width_val isnt 'select'
+        width_val = null unless width_val and width_val isnt 'select'
+        # @$select_width can only represent w1-w10, so a width outside that
+        # range is never reflected there — fall back to whatever token is
+        # still on the model so it isn't destroyed on an unrelated edit.
+        width_val ?= getWidthTokenFromModelValue(@model.get('value') or '')
+        if width_val
           value = if value then "#{value} #{width_val}" else width_val
       @model.set 'value', value
 
@@ -1428,7 +1461,7 @@ module.exports = do ->
               select_value = select_model_value
               modelValue = modelValue.split(select_value).join('')
 
-            width_model_value = @get_width_from_model_value()
+            width_model_value = @get_width_token_from_model_value()
             if width_model_value?
               select_width_value = width_model_value
               modelValue = modelValue.split(select_width_value).join('')
@@ -1464,7 +1497,7 @@ module.exports = do ->
           $input = @$('input')
           if modelValue? and modelValue != ''
             modelValue = modelValue.trim()
-            width_model_value = @get_width_from_model_value()
+            width_model_value = @get_width_token_from_model_value()
             if width_model_value?
               modelValue = modelValue.split(width_model_value).join('').trim()
             if modelValue != ''
@@ -1478,16 +1511,15 @@ module.exports = do ->
 
     _afterRenderWidth: ->
       return unless @is_form_style_theme_grid()
-      $advBody = @rowView.cardSettingsWrap.find('#js-card-settings-row-options-advanced').eq(0)
-      return unless $advBody.length
+      return unless @rowView.cardSettingsWrap.find('.js-card-settings-advanced-toggle').length
 
-      # Idempotent: remove stale sub-section from a prior render
-      $advBody.find('.js-item-width-wrap').remove()
+      # Idempotent: remove stale section from a prior render
+      @rowView.cardSettingsWrap.find('.js-item-width-wrap').remove()
 
       groupCols = getParentGroupCols(@)
       groupName = getParentGroupName(@)
       modelValue = @model.get('value') or ''
-      currentW  = getWidthFromModelValue(modelValue)
+      currentW  = getWidthTokenFromModelValue(modelValue)
 
       # Context line text
       if groupName?
@@ -1515,7 +1547,7 @@ module.exports = do ->
       selectedW  = if outOfRange then null else if currentW? then currentW else defaultW
 
       # --- Build DOM ---
-      $wrap = $('<div/>', { class: 'js-item-width-wrap item-width-subsection', style: 'grid-column: 1 / -1' })
+      $wrap = $('<div/>', { class: 'js-item-width-wrap item-width-section', style: 'grid-column: 1 / -1' })
 
       # Header row (collapse toggle)
       $header = $('<button/>', {
@@ -1523,7 +1555,7 @@ module.exports = do ->
         type: 'button'
         'aria-expanded': 'false'
       })
-      $header.append($('<span/>', { class: 'item-width__title' }).text(t('Item width in group grid')))
+      $header.append($('<span/>', { class: 'item-width__title' }).text(t('Item width')))
       $pill = $('<span/>', { class: 'js-item-width-pill item-width__pill', style: 'display:none' })
       $header.append($pill)
       $chev = $('<i/>', { class: 'k-icon k-icon-angle-down item-width__chev', 'aria-hidden': 'true' })
@@ -1571,7 +1603,8 @@ module.exports = do ->
 
       $body.hide()
       $wrap.append($body)
-      $advBody.prepend($wrap)
+      $advancedToggle = @rowView.cardSettingsWrap.find('.js-card-settings-advanced-toggle').eq(0)
+      $wrap.insertBefore($advancedToggle)
 
       @_refreshWidthPill($pill)
       $pill.show()
@@ -1647,7 +1680,7 @@ module.exports = do ->
       $grid = $('<div/>', { class: 'group-cols__grid' })
       for numCols in [1..10]
         isSelected = currentSelCols is numCols
-        isDefaultCard = numCols is DEFAULT_COLS and not currentSelCols?
+        isDefaultCard = numCols is DEFAULT_COLS and not currentSelCols? and not outOfRange
         $card = $('<div/>', {
           class: "group-cols-card#{if isSelected then ' is-selected' else ''}#{if isDefaultCard then ' is-default' else ''}"
           'data-cols': numCols
@@ -1673,9 +1706,12 @@ module.exports = do ->
       @rowView.cardSettingsWrap.find('.js-card-settings-appearance').eq(0).after($wrap)
 
       refreshPill = =>
-        numCols = currentSelCols ? DEFAULT_COLS
-        colWord = if numCols is 1 then t('column') else t('columns')
-        $pill.text(if currentSelCols? then "#{numCols} #{colWord} · w#{numCols}" else "#{numCols} #{colWord}")
+        if outOfRange
+          $pill.text(storedVal)
+        else
+          numCols = currentSelCols ? DEFAULT_COLS
+          colWord = if numCols is 1 then t('column') else t('columns')
+          $pill.text(if currentSelCols? then "#{numCols} #{colWord} · w#{numCols}" else "#{numCols} #{colWord}")
 
       refreshPill()
       $pill.show()
@@ -1683,6 +1719,8 @@ module.exports = do ->
       selectCols = (el) =>
         numCols = parseInt($(el).data('cols'), 10)
         currentSelCols = numCols
+        outOfRange = false
+        $body.find('.group-cols__advisory').remove()
         @$select_width.val("w#{numCols}")
         if @_card?
           @_writeModelValue()
@@ -1730,7 +1768,7 @@ module.exports = do ->
 
     _refreshWidthPill: ($pill) ->
       groupCols = getParentGroupCols(@)
-      currentW  = getWidthFromModelValue(@model.get('value') or '')
+      currentW  = getWidthTokenFromModelValue(@model.get('value') or '')
       unless currentW?
         currentW = if groupCols is 4 then 'w4' else "w#{groupCols}"
       label = buildWidthPillText(currentW, groupCols)
@@ -1829,7 +1867,7 @@ module.exports = do ->
 
       # Preserve item width token managed by the Item width section
       if @is_form_style_theme_grid()
-        existingWidth = getWidthFromModelValue(@model.get('value') or '')
+        existingWidth = getWidthTokenFromModelValue(@model.get('value') or '')
         if existingWidth
           model_set_value = if model_set_value != '' then "#{model_set_value} #{existingWidth}" else existingWidth
 
@@ -1861,7 +1899,7 @@ module.exports = do ->
           model_set_value = select_width_value
       else if @is_form_style_theme_grid()
         # Non-group textbox: preserve item width token
-        existingWidth = getWidthFromModelValue(@model.get('value') or '')
+        existingWidth = getWidthTokenFromModelValue(@model.get('value') or '')
         if existingWidth
           model_set_value = if model_set_value != '' then "#{model_set_value} #{existingWidth}" else existingWidth
 
@@ -2372,6 +2410,7 @@ module.exports = do ->
   viewRowDetail.buildModelValue = buildModelValue
   viewRowDetail.buildPillText = buildPillText
   viewRowDetail.getWidthFromModelValue = getWidthFromModelValue
+  viewRowDetail.getWidthTokenFromModelValue = getWidthTokenFromModelValue
   viewRowDetail.buildWidthPillText = buildWidthPillText
 
   viewRowDetail

--- a/test/xlform/rowDetail.tests.coffee
+++ b/test/xlform/rowDetail.tests.coffee
@@ -794,13 +794,73 @@ do ->
     it 'extracts wN when it appears first', ->
       expect(getWidthFromModelValue('w2 minimal')).toBe('w2')
 
-    it 'returns last matched wN when multiple present (highest wins)', ->
-      # iterates w1..w10 in order, last match wins
+    it 'returns highest-numbered wN when multiple present', ->
       result = getWidthFromModelValue('w2 w5')
       expect(result).toBe('w5')
 
-    it 'does not match partial token: w11 returns null', ->
+    it 'returns null for an unsupported (out-of-range) token: w11', ->
+      # w11 is a real, fully-formed token — it is just not one of the
+      # w1-w10 options this reader is limited to. It must not be confused
+      # with "no width stored" by callers; see getWidthTokenFromModelValue
+      # below for the reader that preserves the raw out-of-range value.
       expect(getWidthFromModelValue('w11')).toBe(null)
+
+    it 'returns null when the only present token is out of range: w14', ->
+      expect(getWidthFromModelValue('w14')).toBe(null)
+
+    it 'returns null when the highest present token is out of range: "w3 w14"', ->
+      expect(getWidthFromModelValue('w3 w14')).toBe(null)
+
+  ###############################################################
+  # Item width helpers: getWidthTokenFromModelValue
+  ###############################################################
+  describe 'getWidthTokenFromModelValue', ->
+    {getWidthTokenFromModelValue} = require('../../jsapp/xlform/src/view.rowDetail')
+
+    it 'returns null for null', ->
+      expect(getWidthTokenFromModelValue(null)).toBe(null)
+
+    it 'returns null for empty string', ->
+      expect(getWidthTokenFromModelValue('')).toBe(null)
+
+    it 'returns null when no wN token present', ->
+      expect(getWidthTokenFromModelValue('minimal')).toBe(null)
+
+    it 'returns w1 for "w1"', ->
+      expect(getWidthTokenFromModelValue('w1')).toBe('w1')
+
+    it 'returns w10 for "w10"', ->
+      expect(getWidthTokenFromModelValue('w10')).toBe('w10')
+
+    it 'preserves an out-of-range token: "w14" returns "w14", not null', ->
+      expect(getWidthTokenFromModelValue('w14')).toBe('w14')
+
+    it 'extracts an out-of-range token from a combined appearance value', ->
+      expect(getWidthTokenFromModelValue('table-list w14')).toBe('w14')
+
+    it 'returns highest-numbered wN when multiple in-range tokens are present', ->
+      expect(getWidthTokenFromModelValue('w2 w5')).toBe('w5')
+
+    it 'returns highest-numbered wN regardless of string order', ->
+      expect(getWidthTokenFromModelValue('w5 w2')).toBe('w5')
+
+    it 'returns the out-of-range token when it is highest: "w3 w14"', ->
+      expect(getWidthTokenFromModelValue('w3 w14')).toBe('w14')
+
+    it 'does not match a partial token: "w14x" returns null', ->
+      expect(getWidthTokenFromModelValue('w14x')).toBe(null)
+
+    it 'does not match a token glued to a preceding letter: "aw14" returns null', ->
+      expect(getWidthTokenFromModelValue('aw14')).toBe(null)
+
+    it 'does not match a leading-zero token: "w01" returns null', ->
+      expect(getWidthTokenFromModelValue('w01')).toBe(null)
+
+    it 'does not match "w0"', ->
+      expect(getWidthTokenFromModelValue('w0')).toBe(null)
+
+    it 'skips a leading-zero token in favor of a real one in the same value', ->
+      expect(getWidthTokenFromModelValue('w01 w5')).toBe('w5')
 
   ###############################################################
   # Item width helpers: buildWidthPillText
@@ -825,6 +885,9 @@ do ->
 
     it 'out-of-range w5 in G=4 → "w5"', ->
       expect(buildWidthPillText('w5', 4)).toBe('w5')
+
+    it 'out-of-range w14 in G=4 → "w14"', ->
+      expect(buildWidthPillText('w14', 4)).toBe('w14')
 
     it 'w1 in G=5 → "1 of 5"', ->
       expect(buildWidthPillText('w1', 5)).toBe('1 of 5')

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -906,3 +906,120 @@ do ->
       # Then select placeholder
       $contactDataSelect.val('select').trigger('change')
       expect(@row.getValue('instance::oc:contactdata')).toBe('')
+
+  ###############################################################
+  # OC-28306 — a stored width token outside w1-w10 (e.g. "w14") must be
+  # shown with an advisory (not silently treated as unset/default) and
+  # must survive an edit to an unrelated control in the same panel.
+  ###############################################################
+
+  describe 'view.rowDetail.DetailViewMixins: "appearance" (group) — out-of-range Columns in Grid width', ->
+    beforeEach ->
+      window.xlfHideWarnings = true
+      sessionStorage.setItem('kpi.editable-form.form-style', 'theme-grid')
+      @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      $model = require('../../jsapp/xlform/src/_model')
+      @survey = new $model.Survey()
+      @survey.rows.add(type: 'group', name: 'grp1', label: 'Group 1', appearance: 'w14')
+      @row = @survey.rows.at(0)
+      @detail = @row.get('appearance')
+      @mixin = @viewRowDetail.DetailViewMixins.appearance
+      @$el = $('<div/>')
+      @$cardSettingsWrap = $('<div><div class="js-card-settings-appearance"></div></div>')
+      @mixin_ctx = $.extend({}, @mixin, {
+        cid: 'cid_grp_appearance'
+        $el: @$el
+        $: (sel) => @$el.find(sel)
+        model: @detail
+        Templates: @viewRowDetail.Templates
+        rowView: { cardSettingsWrap: @$cardSettingsWrap, model: @row }
+      })
+      # html() must run first: it creates @$select_width, which afterRender()
+      # (via _afterRenderCardGrid/_writeModelValue) depends on.
+      @mixin_ctx.html()
+    afterEach ->
+      window.xlfHideWarnings = false
+      sessionStorage.removeItem('kpi.editable-form.form-style')
+
+    it 'shows the out-of-range advisory and highlights no card (not card 4)', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $wrap = @$cardSettingsWrap.find('.js-group-cols-wrap')
+      expect($wrap.length).toBe(1)
+      expect($wrap.find('.group-cols-card.is-selected').length).toBe(0)
+      expect($wrap.find('.group-cols-card.is-default').length).toBe(0)
+      $advisory = $wrap.find('.group-cols__advisory')
+      expect($advisory.length).toBe(1)
+      expect($advisory.text().indexOf('w14')).not.toBe(-1)
+
+    it 'shows the raw stored token as the collapsed-state pill, not "4 columns"', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $pill = @$cardSettingsWrap.find('.js-group-cols-pill')
+      expect($pill.text()).toBe('w14')
+
+    it 'preserves the out-of-range width when only the Appearance card is changed', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $tableListCard = @$el.find('.appearance-card[data-card-slug="table-list"]')
+      expect($tableListCard.length).toBe(1)
+      $tableListCard.trigger('click')
+      expect(@detail.get('value')).toBe('table-list w14')
+
+    it 'clears the advisory and default-card state once the user picks a real column count', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $wrap = @$cardSettingsWrap.find('.js-group-cols-wrap')
+      $card6 = $wrap.find('.group-cols-card[data-cols="6"]')
+      expect($card6.length).toBe(1)
+      $card6.trigger('click')
+      expect($wrap.find('.group-cols__advisory').length).toBe(0)
+      expect($card6.hasClass('is-selected')).toBe(true)
+      expect(@detail.get('value')).toBe('w6')
+
+  describe 'view.rowDetail.DetailViewMixins: "appearance" (item) — out-of-range Item width', ->
+    beforeEach ->
+      window.xlfHideWarnings = true
+      sessionStorage.setItem('kpi.editable-form.form-style', 'theme-grid')
+      @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      $model = require('../../jsapp/xlform/src/_model')
+      @survey = new $model.Survey()
+      @survey.rows.add(type: 'text', name: 'q1', label: 'Q1', appearance: 'w14')
+      @row = @survey.rows.at(0)
+      @detail = @row.get('appearance')
+      @mixin = @viewRowDetail.DetailViewMixins.appearance
+      @$el = $('<div/>')
+      # _afterRenderWidth inserts the item-width section as a sibling right
+      # before '.js-card-settings-advanced-toggle' (see OC-28234).
+      @$cardSettingsWrap = $('<div><div class="js-card-settings-advanced-toggle"></div></div>')
+      @mixin_ctx = $.extend({}, @mixin, {
+        cid: 'cid_item_appearance'
+        $el: @$el
+        $: (sel) => @$el.find(sel)
+        model: @detail
+        Templates: @viewRowDetail.Templates
+        rowView: { cardSettingsWrap: @$cardSettingsWrap, model: @row }
+      })
+      @mixin_ctx.html()
+    afterEach ->
+      window.xlfHideWarnings = false
+      sessionStorage.removeItem('kpi.editable-form.form-style')
+
+    it 'shows the out-of-range advisory and highlights no width card', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $wrap = @$cardSettingsWrap.find('.js-item-width-wrap')
+      expect($wrap.length).toBe(1)
+      expect($wrap.find('.width-card.is-selected').length).toBe(0)
+      $advisory = $wrap.find('.item-width__advisory')
+      expect($advisory.length).toBe(1)
+      expect($advisory.text().indexOf('w14')).not.toBe(-1)
+
+    it 'shows the raw stored token in the collapsed-state pill, not "Full width"', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $pill = @$cardSettingsWrap.find('.js-item-width-pill')
+      # buildWidthPillText has no dedicated out-of-range copy, so both the
+      # label and the raw token render as "w14" — redundant but not wrong.
+      expect($pill.text().trim()).toBe('w14 · w14')
+
+    it 'preserves the out-of-range width when only the Appearance card is changed', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      $paragraphCard = @$el.find('.appearance-card[data-card-slug="paragraph"]')
+      expect($paragraphCard.length).toBe(1)
+      $paragraphCard.trigger('click')
+      expect(@detail.get('value')).toBe('multiline w14')


### PR DESCRIPTION
## Summary
- A stored width appearance token outside `w1`-`w10` (e.g. `w14`) was indistinguishable from "unset" to `getWidthFromModelValue`, so the Columns in Grid / Item width pickers showed no advisory and falsely highlighted the default card (OC-28023 AC4 failure).
- The same value was then silently destroyed the next time the user edited any unrelated control in the same settings panel (e.g. clicking an Appearance card), since `_writeModelValue`'s only width register (`@$select_width`) can only represent `w1`-`w10`.
- Added `getWidthTokenFromModelValue` as a raw, any-range reader for preservation/display, kept the original range-limited for call sites that feed something that can only hold `w1`-`w10`, and fixed `_afterRenderGroupCols`'s default-card/pill/advisory logic, which conflated "out of range" with "unset" independently of the parser bug.
- Scope: groups and items. The legacy `repeat`-group path is deliberately untouched — broadening the fix there risks corrupting values (verified empirically), so it's left for a follow-up.

## Test plan
- [x] `npx jest --config ./jsapp/jest/unit.config.ts test/xlform/` — 1157 passed, 0 failed
- [x] New/changed tests independently confirmed to fail against the pre-fix code and pass after (not vacuous)
- [x] Independent code review pass (no Critical issues; two Important suggestions addressed: documented a mixed-token edge case, added pill-text assertions for both out-of-range paths)
- [x] Manual verification in a running Form Designer against a group with `appearance: "w14"`: no card falsely selected/defaulted, advisory shown ("Saved value (w14) is outside the supported range..."), collapsed pill reads `w14`. Editing the Appearance card to Table list and saving preserves it server-side as `table-list w14` (previously collapsed to bare `table-list`, losing the width). Picking a real column count afterward correctly clears the advisory and saves as `table-list w6`.