### PR TITLE
OC-28304: Resolve users.xml/clinicaldata.xml refs in FD preview

### DIFF
--- a/kpi/tests/test_study_designer_preview.py
+++ b/kpi/tests/test_study_designer_preview.py
@@ -79,6 +79,51 @@ class DecorateSnapshotWithStudyDesignerPreviewTest(TestCase):
     @patch('kpi.utils.study_designer_preview._cached_client_secret')
     @patch('kpi.utils.study_designer_preview._cached_realm_name')
     @responses.activate
+    def test_rewrites_users_and_clinicaldata_instance_refs(
+        self, mock_realm, mock_secret, mock_keycloak
+    ):
+        self._mock_keycloak(mock_realm, mock_secret, mock_keycloak)
+        responses.add(
+            responses.POST,
+            self.form_service_url,
+            body=(
+                '<h:html><h:head><model>'
+                '<instance id="_users" src="jr://file-csv/users.xml"/>'
+                '<instance id="clinicaldata" src="jr://file/clinicaldata.xml"/>'
+                '</model></h:head></h:html>'
+            ),
+            status=200,
+        )
+
+        decorate_snapshot_with_study_designer_preview(self.snapshot, self.request)
+
+        expected_users_url = settings.ENKETO_FORM_OC_INSTANCE_URL.replace(
+            'clinicaldata.xml', 'users.xml'
+        )
+        self.assertIn(expected_users_url, self.snapshot.xml)
+        self.assertIn(settings.ENKETO_FORM_OC_INSTANCE_URL, self.snapshot.xml)
+        self.assertNotIn('jr://file-csv/users.xml', self.snapshot.xml)
+        self.assertNotIn('jr://file/clinicaldata.xml', self.snapshot.xml)
+
+    @patch('kpi.utils.study_designer_preview.KeycloakOpenID')
+    @patch('kpi.utils.study_designer_preview._cached_client_secret')
+    @patch('kpi.utils.study_designer_preview._cached_realm_name')
+    @responses.activate
+    def test_leaves_xml_without_users_or_clinicaldata_refs_unchanged(
+        self, mock_realm, mock_secret, mock_keycloak
+    ):
+        self._mock_keycloak(mock_realm, mock_secret, mock_keycloak)
+        body = '<h:html><!-- decorated, no users/clinicaldata refs --></h:html>'
+        responses.add(responses.POST, self.form_service_url, body=body, status=200)
+
+        decorate_snapshot_with_study_designer_preview(self.snapshot, self.request)
+
+        self.assertEqual(self.snapshot.xml, body)
+
+    @patch('kpi.utils.study_designer_preview.KeycloakOpenID')
+    @patch('kpi.utils.study_designer_preview._cached_client_secret')
+    @patch('kpi.utils.study_designer_preview._cached_realm_name')
+    @responses.activate
     def test_falls_back_on_non_200(self, mock_realm, mock_secret, mock_keycloak):
         self._mock_keycloak(mock_realm, mock_secret, mock_keycloak)
         responses.add(responses.POST, self.form_service_url, status=400)

--- a/kpi/tests/test_study_designer_preview.py
+++ b/kpi/tests/test_study_designer_preview.py
@@ -75,6 +75,12 @@ class DecorateSnapshotWithStudyDesignerPreviewTest(TestCase):
         self.assertNotIn(b'media_base_url', sent_request.body)
         self.assertEqual(sent_request.headers['Authorization'], 'Bearer test-token')
 
+    @override_settings(
+        ENKETO_FORM_OC_INSTANCE_URL=(
+            'https://build.test/form-service/api/storage/artifacts/'
+            'clinicaldata.xml'
+        )
+    )
     @patch('kpi.utils.study_designer_preview.KeycloakOpenID')
     @patch('kpi.utils.study_designer_preview._cached_client_secret')
     @patch('kpi.utils.study_designer_preview._cached_realm_name')
@@ -97,11 +103,15 @@ class DecorateSnapshotWithStudyDesignerPreviewTest(TestCase):
 
         decorate_snapshot_with_study_designer_preview(self.snapshot, self.request)
 
-        expected_users_url = settings.ENKETO_FORM_OC_INSTANCE_URL.replace(
-            'clinicaldata.xml', 'users.xml'
+        self.assertIn(
+            'https://build.test/form-service/api/storage/artifacts/users.xml',
+            self.snapshot.xml,
         )
-        self.assertIn(expected_users_url, self.snapshot.xml)
-        self.assertIn(settings.ENKETO_FORM_OC_INSTANCE_URL, self.snapshot.xml)
+        self.assertIn(
+            'https://build.test/form-service/api/storage/artifacts/'
+            'clinicaldata.xml',
+            self.snapshot.xml,
+        )
         self.assertNotIn('jr://file-csv/users.xml', self.snapshot.xml)
         self.assertNotIn('jr://file/clinicaldata.xml', self.snapshot.xml)
 

--- a/kpi/utils/study_designer_preview.py
+++ b/kpi/utils/study_designer_preview.py
@@ -110,7 +110,18 @@ def _fetch_decorated_xml(snapshot, request):
         )
         return None
 
-    return xml
+    # generateXform never rewrites these two refs (by design: no persisted
+    # data files exist for a stateless request), so point them at
+    # form-service's existing stub-file route ourselves, same as the
+    # deployed/Study Designer upload pipeline does. users.xml lives
+    # alongside clinicaldata.xml in that same artifacts folder, so derive
+    # its URL from the existing per-environment setting instead of adding
+    # a new one.
+    clinicaldata_url = settings.ENKETO_FORM_OC_INSTANCE_URL
+    users_url = clinicaldata_url.replace('clinicaldata.xml', 'users.xml')
+    return xml.replace('jr://file-csv/users.xml', users_url).replace(
+        'jr://file/clinicaldata.xml', clinicaldata_url
+    )
 
 
 def _cached_client_credentials_token(realm_name):

--- a/kpi/utils/study_designer_preview.py
+++ b/kpi/utils/study_designer_preview.py
@@ -118,7 +118,7 @@ def _fetch_decorated_xml(snapshot, request):
     # its URL from the existing per-environment setting instead of adding
     # a new one.
     clinicaldata_url = settings.ENKETO_FORM_OC_INSTANCE_URL
-    users_url = clinicaldata_url.replace('clinicaldata.xml', 'users.xml')
+    users_url = clinicaldata_url.rsplit('/', 1)[0] + '/users.xml'
     return xml.replace('jr://file-csv/users.xml', users_url).replace(
         'jr://file/clinicaldata.xml', clinicaldata_url
     )


### PR DESCRIPTION
## Summary
- Form Designer preview's stateless `generateXform` call (OC-28086/OC-28087) never rewrites the `jr://file-csv/users.xml` ref that form-service's query-flavor decorator injects into every form's model, or `jr://file/clinicaldata.xml` for cross-form-reference forms — by design, since no persisted data files exist for a stateless request. Enketo couldn't resolve either instance, showing "Can't find users.xml"/"Can't find clinicaldata.xml" and hiding the Validate button, even on forms with no cross-form reference.
- `decorate_snapshot_with_study_designer_preview` now rewrites both refs itself before persisting the decorated XML, pointing them at form-service's existing `/api/storage/artifacts/{users,clinicaldata}.xml` stub files (already used successfully by the deployed Study Designer preview flow).
- No new setting: derives the `users.xml` URL from the existing per-environment `ENKETO_FORM_OC_INSTANCE_URL` (already correctly configured in `container-ops` for dev/staging/prod/local, always ending in `.../artifacts/clinicaldata.xml`) instead of adding a new one.

## Test plan
- [x] New tests in `test_study_designer_preview.py`: both refs get rewritten to the derived URLs; a response with neither ref passes through unchanged.
- [x] Manual: reproduced locally in Form Designer — confirmed the "Can't find users.xml" popup and missing Validate button on a plain-text-only form, then confirmed the fix resolves it after rebuild/redeploy.
- [x] Manual: repeated with a form using `bind::oc:external=clinicaldata` (cross-form reference) — confirms clinicaldata resolution and no regression.