### PR TITLE
OC-28363 Hide grid-only sections on form style change

### DIFF
--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -331,6 +331,9 @@ export default function EditableForm(props: EditableFormProps) {
     }))
     // OC fork: cache the selected form style so it survives a re-launch.
     sessionStorage.setItem(FORM_STYLE_CACHE_NAME, settingsStyle ?? '')
+    // OC fork: notify open Question Options panels to re-render grid-only
+    // sections (Columns in Grid, Item Width) immediately on style change.
+    window.dispatchEvent(new CustomEvent('ocFormStyleChange'))
     onSurveyChangeDebounced()
   }
 

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -333,7 +333,7 @@ export default function EditableForm(props: EditableFormProps) {
     sessionStorage.setItem(FORM_STYLE_CACHE_NAME, settingsStyle ?? '')
     // OC fork: notify open Question Options panels to re-render grid-only
     // sections (Columns in Grid, Item Width) immediately on style change.
-    window.dispatchEvent(new CustomEvent('ocFormStyleChange'))
+    document.dispatchEvent(new CustomEvent('ocFormStyleChange'))
     onSurveyChangeDebounced()
   }
 

--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -451,12 +451,13 @@ module.exports = do ->
 
     _cleanupExpandedRender: ->
       # Remove the appearance DetailView so its ocFormStyleChange listener is
-      # unregistered before the settings panel detaches (remove() never fires
-      # otherwise because _cleanupExpandedRender only detaches the DOM).
+      # unregistered before the settings panel detaches.
       if @_appearanceDV
         @_appearanceDV.remove()
         @_appearanceDV = null
-      @$('.card__settings').detach()
+      # Scope to this view's own panel via the stored ref to avoid detaching
+      # descendant rows' expanded panels when collapsing a group.
+      @cardSettingsWrap?.detach()
 
     clone: (event) ->
       parent = @model._parent
@@ -537,6 +538,9 @@ module.exports = do ->
       return
 
     _deleteGroup: () ->
+      # Clean up any expanded settings panel before detach so the
+      # ocFormStyleChange listener and _appearanceDV are properly removed.
+      @toggleSettings(false) if @_settingsExpanded
       @model.splitApart()
       @model._parent._parent.trigger('remove', @model)
       @surveyView.survey.trigger('change')

--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -450,6 +450,12 @@ module.exports = do ->
       ``
 
     _cleanupExpandedRender: ->
+      # Remove the appearance DetailView so its ocFormStyleChange listener is
+      # unregistered before the settings panel detaches (remove() never fires
+      # otherwise because _cleanupExpandedRender only detaches the DOM).
+      if @_appearanceDV
+        @_appearanceDV.remove()
+        @_appearanceDV = null
       @$('.card__settings').detach()
 
     clone: (event) ->

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -208,15 +208,17 @@ module.exports = do ->
 
       Backbone.on('ocCustomEvent', @onOcCustomEvent, @)
       Backbone.on('ocConsentRowsEvent', @onOcConsentRowsEvent, @)
+      # onOcFormStyleChange is defined only in DetailViewMixins.appearance, so
+      # non-appearance views must not subscribe to this event.
       if @onOcFormStyleChange?
         @_onOcFormStyleChangeBound = => @onOcFormStyleChange()
-        window.addEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
+        document.addEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
 
       return
 
     remove: ->
       if @_onOcFormStyleChangeBound
-        window.removeEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
+        document.removeEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
       Backbone.off(null, null, @)
       super
 
@@ -1214,6 +1216,9 @@ module.exports = do ->
 
     afterRender: ->
       if @isCardGridType()
+        # Store a back-reference so _cleanupExpandedRender can call remove() and
+        # clear the ocFormStyleChange listener before the settings panel detaches.
+        @rowView._appearanceDV = @
         @_afterRenderCardGrid()
       else
         @rowView.cardSettingsWrap.find('.js-card-settings-appearance').eq(0).hide()
@@ -1232,7 +1237,9 @@ module.exports = do ->
         else
           @_afterRenderWidth()
       else
-        # Switching AWAY from grid — remove the sections immediately
+        # Switching AWAY from grid — remove the sections immediately.
+        # Selectors below must stay in sync with those used by _afterRenderGroupCols
+        # and _afterRenderWidth; if either changes its wrapper class, update here too.
         if questionType is 'group'
           @rowView.cardSettingsWrap.find('.js-group-cols-wrap').remove()
         else

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -208,11 +208,6 @@ module.exports = do ->
 
       Backbone.on('ocCustomEvent', @onOcCustomEvent, @)
       Backbone.on('ocConsentRowsEvent', @onOcConsentRowsEvent, @)
-      # onOcFormStyleChange is defined only in DetailViewMixins.appearance, so
-      # non-appearance views must not subscribe to this event.
-      if @onOcFormStyleChange?
-        @_onOcFormStyleChangeBound = => @onOcFormStyleChange()
-        document.addEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
 
       return
 
@@ -244,7 +239,7 @@ module.exports = do ->
           val = @model.get('value')
           if val is true or val in $configs.truthyValues
             $el.prop('checked', true)
-      @model.on 'change:value', reflectValueInEl
+      @listenTo @model, 'change:value', reflectValueInEl
       reflectValueInEl()
 
       $el.on 'change', ()=>
@@ -289,7 +284,7 @@ module.exports = do ->
             $el.val(modelVal)
 
       reflectValueInEl()
-      @model.on 'change:value', reflectValueInEl
+      @listenTo @model, 'change:value', reflectValueInEl
 
       detectAndChangeValue = () =>
         $elVal = $el.val()
@@ -1184,7 +1179,7 @@ module.exports = do ->
 
     model_get_parent_group: ->
       parent_group = null
-      if @model._parent._parent._parent? and @model._parent._parent._parent.constructor.key == 'group'
+      if @model?._parent?._parent?._parent? and @model._parent._parent._parent.constructor.key == 'group'
         parent_group = @model._parent._parent._parent
       parent_group
 
@@ -1216,9 +1211,12 @@ module.exports = do ->
 
     afterRender: ->
       if @isCardGridType()
-        # Store a back-reference so _cleanupExpandedRender can call remove() and
-        # clear the ocFormStyleChange listener before the settings panel detaches.
+        # Register the ocFormStyleChange listener here (not in initialize) so the
+        # gate, the _appearanceDV back-ref, and the listener are all set together
+        # only for card-grid types. Non-card-grid types never register or leak.
         @rowView._appearanceDV = @
+        @_onOcFormStyleChangeBound = => @onOcFormStyleChange()
+        document.addEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
         @_afterRenderCardGrid()
       else
         @rowView.cardSettingsWrap.find('.js-card-settings-appearance').eq(0).hide()
@@ -1228,12 +1226,17 @@ module.exports = do ->
     # form style changes, so they appear/disappear immediately without requiring
     # the user to interact further with the panel.
     onOcFormStyleChange: ->
+      # Guard against deleted rows — row.detach() nulls _parent, and walking
+      # _parent._parent._parent in model_get_parent_group would throw.
+      return unless @model?._parent?
       return unless @isCardGridType()
       questionType = @model_type()
       if @is_form_style_theme_grid()
-        # Switching TO grid — render the sections
+        # Switching TO grid — render the sections.
+        # Use get_width_token_from_model_value (not get_width_from_model_value) to
+        # preserve out-of-range tokens like w14 from migrated 3.x forms (OC-28306).
         if questionType is 'group'
-          @_afterRenderGroupCols(@get_width_from_model_value())
+          @_afterRenderGroupCols(@get_width_token_from_model_value())
         else
           @_afterRenderWidth()
       else
@@ -1331,7 +1334,7 @@ module.exports = do ->
         toggleSection() if evt.key in ['Enter', ' ']
 
       # Keep pill fresh when model changes from outside (e.g. loading)
-      @model.on 'change:value', =>
+      @listenTo @model, 'change:value', =>
         if $section.hasClass('is-collapsed')
           val = @model.get('value') or ''
           { card, columnCount, customText } = parseAppearanceValue(val, questionType)

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -208,8 +208,9 @@ module.exports = do ->
 
       Backbone.on('ocCustomEvent', @onOcCustomEvent, @)
       Backbone.on('ocConsentRowsEvent', @onOcConsentRowsEvent, @)
-      @_onOcFormStyleChangeBound = => @onOcFormStyleChange()
-      window.addEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
+      if @onOcFormStyleChange?
+        @_onOcFormStyleChangeBound = => @onOcFormStyleChange()
+        window.addEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
 
       return
 
@@ -1227,7 +1228,7 @@ module.exports = do ->
       if @is_form_style_theme_grid()
         # Switching TO grid — render the sections
         if questionType is 'group'
-          @_afterRenderGroupCols(@get_width_token_from_model_value())
+          @_afterRenderGroupCols(@get_width_from_model_value())
         else
           @_afterRenderWidth()
       else

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -208,8 +208,16 @@ module.exports = do ->
 
       Backbone.on('ocCustomEvent', @onOcCustomEvent, @)
       Backbone.on('ocConsentRowsEvent', @onOcConsentRowsEvent, @)
+      @_onOcFormStyleChangeBound = => @onOcFormStyleChange()
+      window.addEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
 
       return
+
+    remove: ->
+      if @_onOcFormStyleChangeBound
+        window.removeEventListener('ocFormStyleChange', @_onOcFormStyleChangeBound)
+      Backbone.off(null, null, @)
+      super
 
     render: ()->
       rendered = @html()
@@ -1209,6 +1217,25 @@ module.exports = do ->
       else
         @rowView.cardSettingsWrap.find('.js-card-settings-appearance').eq(0).hide()
         @_afterRenderLegacy()
+
+    # Re-render the grid-only sections (Columns in Grid + Item Width) when the
+    # form style changes, so they appear/disappear immediately without requiring
+    # the user to interact further with the panel.
+    onOcFormStyleChange: ->
+      return unless @isCardGridType()
+      questionType = @model_type()
+      if @is_form_style_theme_grid()
+        # Switching TO grid — render the sections
+        if questionType is 'group'
+          @_afterRenderGroupCols(@get_width_token_from_model_value())
+        else
+          @_afterRenderWidth()
+      else
+        # Switching AWAY from grid — remove the sections immediately
+        if questionType is 'group'
+          @rowView.cardSettingsWrap.find('.js-group-cols-wrap').remove()
+        else
+          @rowView.cardSettingsWrap.find('.js-item-width-wrap').remove()
 
     # -------------------------------------------------------------------------
     # Card grid path (select_one / select_multiple)

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -818,6 +818,10 @@ module.exports = do ->
     _deleteRow: (row) ->
       $row = $("li[data-row-id='#{row.cid}']")
       parent = row._parent._parent
+      # Clean up any expanded settings panel before detach so the
+      # ocFormStyleChange listener and _appearanceDV are properly removed.
+      rowView = @__rowViews.get(row.cid)
+      rowView?.toggleSettings(false) if rowView?._settingsExpanded
       row.detach()
       # this slideUp is for add/remove row animation
       $row.addClass('survey__row--deleted')

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -931,6 +931,7 @@ do ->
         $el: @$el
         $: (sel) => @$el.find(sel)
         model: @detail
+        listenTo: ->
         Templates: @viewRowDetail.Templates
         rowView: { cardSettingsWrap: @$cardSettingsWrap, model: @row }
       })
@@ -993,6 +994,7 @@ do ->
         $el: @$el
         $: (sel) => @$el.find(sel)
         model: @detail
+        listenTo: ->
         Templates: @viewRowDetail.Templates
         rowView: { cardSettingsWrap: @$cardSettingsWrap, model: @row }
       })
@@ -1039,6 +1041,7 @@ do ->
 
       @ctx =
         rowView: cardSettingsWrap: @cardSettingsWrap
+        model: _parent: {}
         isCardGridType: -> true
         is_form_style_theme_grid: -> false
         model_type: -> 'select_one'

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -1023,3 +1023,61 @@ do ->
       expect($paragraphCard.length).toBe(1)
       $paragraphCard.trigger('click')
       expect(@detail.get('value')).toBe('multiline w14')
+
+  ###############################################################
+  # view.rowDetail: DetailViewMixins.appearance — onOcFormStyleChange
+  ###############################################################
+  describe 'view.rowDetail.DetailViewMixins.appearance: onOcFormStyleChange()', ->
+    beforeEach ->
+      window.t ?= (str) -> str
+      @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      @mixin = @viewRowDetail.DetailViewMixins.appearance
+
+      # Minimal cardSettingsWrap with stub grid-only section elements
+      @$groupColsWrap = $('<div class="js-group-cols-wrap">').appendTo($('body'))
+      @$itemWidthWrap = $('<div class="js-item-width-wrap">').appendTo($('body'))
+      @cardSettingsWrap = $('<div class="card__settings">')
+        .append(@$groupColsWrap)
+        .append(@$itemWidthWrap)
+        .appendTo($('body'))
+
+      @ctx =
+        rowView: cardSettingsWrap: @cardSettingsWrap
+        isCardGridType: -> true
+        is_form_style_theme_grid: -> false
+        model_type: -> 'select_one'
+        _afterRenderGroupCols: jasmine.createSpy('_afterRenderGroupCols')
+        _afterRenderWidth: jasmine.createSpy('_afterRenderWidth')
+        get_width_from_model_value: -> null
+
+    afterEach ->
+      @cardSettingsWrap.remove()
+
+    it 'returns early when not a card grid type', ->
+      @ctx.isCardGridType = -> false
+      @mixin.onOcFormStyleChange.call(@ctx)
+      expect(@ctx._afterRenderWidth).not.toHaveBeenCalled()
+
+    it 'switching TO grid on a non-group calls _afterRenderWidth', ->
+      @ctx.is_form_style_theme_grid = -> true
+      @ctx.model_type = -> 'select_one'
+      @mixin.onOcFormStyleChange.call(@ctx)
+      expect(@ctx._afterRenderWidth).toHaveBeenCalled()
+
+    it 'switching TO grid on a group calls _afterRenderGroupCols', ->
+      @ctx.is_form_style_theme_grid = -> true
+      @ctx.model_type = -> 'group'
+      @mixin.onOcFormStyleChange.call(@ctx)
+      expect(@ctx._afterRenderGroupCols).toHaveBeenCalled()
+
+    it 'switching AWAY from grid on a non-group removes .js-item-width-wrap', ->
+      @ctx.is_form_style_theme_grid = -> false
+      @ctx.model_type = -> 'select_one'
+      @mixin.onOcFormStyleChange.call(@ctx)
+      expect(@cardSettingsWrap.find('.js-item-width-wrap').length).toBe(0)
+
+    it 'switching AWAY from grid on a group removes .js-group-cols-wrap', ->
+      @ctx.is_form_style_theme_grid = -> false
+      @ctx.model_type = -> 'group'
+      @mixin.onOcFormStyleChange.call(@ctx)
+      expect(@cardSettingsWrap.find('.js-group-cols-wrap').length).toBe(0)

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -1044,7 +1044,7 @@ do ->
         model_type: -> 'select_one'
         _afterRenderGroupCols: ->
         _afterRenderWidth: ->
-        get_width_from_model_value: -> null
+        get_width_token_from_model_value: -> null
 
     it 'returns early when not a card grid type', ->
       widthCalled = false

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -1033,42 +1033,41 @@ do ->
       @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
       @mixin = @viewRowDetail.DetailViewMixins.appearance
 
-      # Minimal cardSettingsWrap with stub grid-only section elements
-      @$groupColsWrap = $('<div class="js-group-cols-wrap">').appendTo($('body'))
-      @$itemWidthWrap = $('<div class="js-item-width-wrap">').appendTo($('body'))
       @cardSettingsWrap = $('<div class="card__settings">')
-        .append(@$groupColsWrap)
-        .append(@$itemWidthWrap)
-        .appendTo($('body'))
+        .append($('<div class="js-group-cols-wrap">'))
+        .append($('<div class="js-item-width-wrap">'))
 
       @ctx =
         rowView: cardSettingsWrap: @cardSettingsWrap
         isCardGridType: -> true
         is_form_style_theme_grid: -> false
         model_type: -> 'select_one'
-        _afterRenderGroupCols: jasmine.createSpy('_afterRenderGroupCols')
-        _afterRenderWidth: jasmine.createSpy('_afterRenderWidth')
+        _afterRenderGroupCols: ->
+        _afterRenderWidth: ->
         get_width_from_model_value: -> null
 
-    afterEach ->
-      @cardSettingsWrap.remove()
-
     it 'returns early when not a card grid type', ->
+      widthCalled = false
       @ctx.isCardGridType = -> false
+      @ctx._afterRenderWidth = -> widthCalled = true
       @mixin.onOcFormStyleChange.call(@ctx)
-      expect(@ctx._afterRenderWidth).not.toHaveBeenCalled()
+      expect(widthCalled).toBe(false)
 
     it 'switching TO grid on a non-group calls _afterRenderWidth', ->
+      widthCalled = false
       @ctx.is_form_style_theme_grid = -> true
       @ctx.model_type = -> 'select_one'
+      @ctx._afterRenderWidth = -> widthCalled = true
       @mixin.onOcFormStyleChange.call(@ctx)
-      expect(@ctx._afterRenderWidth).toHaveBeenCalled()
+      expect(widthCalled).toBe(true)
 
     it 'switching TO grid on a group calls _afterRenderGroupCols', ->
+      groupColsCalled = false
       @ctx.is_form_style_theme_grid = -> true
       @ctx.model_type = -> 'group'
+      @ctx._afterRenderGroupCols = -> groupColsCalled = true
       @mixin.onOcFormStyleChange.call(@ctx)
-      expect(@ctx._afterRenderGroupCols).toHaveBeenCalled()
+      expect(groupColsCalled).toBe(true)
 
     it 'switching AWAY from grid on a non-group removes .js-item-width-wrap', ->
       @ctx.is_form_style_theme_grid = -> false


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
When form style is changed from Grid to Single Page, the Columns in Grid and Item Width sections in the Question Options panel now hide immediately without requiring further user interaction.

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
