### PR TITLE
OC-28400 : save grid item width correctly on appearance change

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1912,6 +1912,7 @@ module.exports = do ->
       stripped = currentVal.replace(/\bw\d+\b/g, '').replace(/\s+/g, ' ').trim()
       newVal = if stripped then "#{stripped} #{widthSlug}" else widthSlug
       @model.set('value', newVal)
+      @$select_width?.val(widthSlug)
 
     _refreshWidthPill: ($pill) ->
       groupCols = getParentGroupCols(@)

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -1285,3 +1285,60 @@ do ->
       expect($paragraphCard.length).toBe(1)
       $paragraphCard.trigger('click')
       expect(detail.get('value')).toBe('multiline')
+
+  ###############################################################
+  # OC-28400: _writeWidthValue must sync $select_width so that a
+  # subsequent _writeModelValue call does not overwrite the newly
+  # selected width with the stale value from render time.
+  ###############################################################
+  describe 'view.rowDetail.DetailViewMixins.appearance: _writeWidthValue syncs $select_width', ->
+    beforeEach ->
+      window.xlfHideWarnings = true
+      sessionStorage.setItem('kpi.editable-form.form-style', 'theme-grid')
+      @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      $model = require('../../jsapp/xlform/src/_model')
+      @survey = new $model.Survey()
+      @survey.rows.add(type: 'group', name: 'grp1', label: 'Group 1', appearance: 'w4')
+      @group = @survey.rows.at(0)
+      @group.rows.add(type: 'select_one', name: 'q1', label: 'Q1', appearance: 'w3')
+      @row = @group.rows.at(0)
+      @detail = @row.get('appearance')
+      @mixin = @viewRowDetail.DetailViewMixins.appearance
+      @$el = $('<div/>')
+      @$cardSettingsWrap = $("""
+        <div>
+          <div class="js-card-settings-appearance">
+            <span class="js-appearance-pill"></span>
+            <button class="js-appearance-toggle"></button>
+          </div>
+          <div class="js-card-settings-advanced-toggle"></div>
+        </div>
+      """)
+      @mixin_ctx = $.extend({}, @mixin, {
+        cid: 'cid_q1_appearance'
+        $el: @$el
+        $: (sel) => @$el.find(sel)
+        model: @detail
+        listenTo: ->
+        Templates: @viewRowDetail.Templates
+        rowView: { cardSettingsWrap: @$cardSettingsWrap, model: @row }
+      })
+      @mixin_ctx.html()
+    afterEach ->
+      window.xlfHideWarnings = false
+      sessionStorage.removeItem('kpi.editable-form.form-style')
+
+    it 'preserves newly selected width when appearance is changed after width', ->
+      # afterRender syncs @$select_width to the stored "w3"
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      # Simulate clicking width card "w2" (user changes from w3 to w2)
+      @mixin_ctx._writeWidthValue.call(@mixin_ctx, 'w2')
+      # Simulate clicking appearance card "paragraph"
+      @mixin_ctx._card = 'paragraph'
+      @mixin_ctx._columnCount = null
+      @mixin_ctx._customText = null
+      @mixin_ctx._writeModelValue.call(@mixin_ctx)
+      # Width must be w2 (new selection), not the stale w3 from render time
+      val = @detail.get('value')
+      expect(val.indexOf('w2')).not.toBe(-1)
+      expect(val.indexOf('w3')).toBe(-1)


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

When a width card is clicked, `$select_width` was not being synced, causing `_writeModelValue` to read the stale old width instead of the new selection when appearance was subsequently changed. Added `@$select_width?.val(widthSlug)` to `_writeWidthValue` to keep them in sync.

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
