### PR TITLE
OC-28410: Refresh customer/role sync on every login, not just signup

### DIFF
--- a/kobo/apps/oc_tenant_auth/adapter.py
+++ b/kobo/apps/oc_tenant_auth/adapter.py
@@ -8,6 +8,7 @@ from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.conf import settings
 from django.core.cache import cache
+from django.db import transaction
 from django.http import HttpResponseForbidden
 
 from .backend import get_realm_name, get_client_secret
@@ -104,7 +105,17 @@ def sync_login_state(request, user, sociallogin):
     """
     Refreshes session/role/user_type on every login — save_user() only
     runs on signup, so relying on it there staled these values (OC-28410).
+
+    Catches and logs failures instead of raising, since user_logged_in
+    propagates exceptions synchronously and could otherwise block login.
     """
+    try:
+        _sync_login_state(request, user, sociallogin)
+    except Exception as exc:
+        LOGGER.error('sync_login_state failed for user %s: %s', user.pk, exc)
+
+
+def _sync_login_state(request, user, sociallogin):
     subdomain = get_subdomain(request)
     extra_data = sociallogin.account.extra_data
     uid = sociallogin.account.uid
@@ -122,9 +133,6 @@ def sync_login_state(request, user, sociallogin):
             token_user_context = token_payload.get(USER_CONTEXT_CLAIM) or {}
         except Exception as exc:
             LOGGER.warning('Failed to decode access_token: %s', exc)
-    user.is_staff = 'admin' in roles or 'superuser' in roles
-    user.is_superuser = 'superuser' in roles
-    user.save(update_fields=['is_staff', 'is_superuser'])
 
     # Populate OC session values from access token
     if access_token and request:
@@ -138,11 +146,18 @@ def sync_login_state(request, user, sociallogin):
 
     user_type = _get_user_context(extra_data).get('userType', '')
 
-    KeycloakTenantUser.objects.update_or_create(
-        UID=uid,
-        subdomain=subdomain,
-        defaults={'user': user, 'user_type': user_type},
-    )
+    # Same transaction: a crash between these two writes must not leave
+    # is_staff/is_superuser updated but user_type stale, or vice versa.
+    with transaction.atomic():
+        user.is_staff = 'admin' in roles or 'superuser' in roles
+        user.is_superuser = 'superuser' in roles
+        user.save(update_fields=['is_staff', 'is_superuser'])
+
+        KeycloakTenantUser.objects.update_or_create(
+            UID=uid,
+            subdomain=subdomain,
+            defaults={'user': user, 'user_type': user_type},
+        )
 
 
 class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):

--- a/kobo/apps/oc_tenant_auth/adapter.py
+++ b/kobo/apps/oc_tenant_auth/adapter.py
@@ -51,6 +51,100 @@ def _extra_data_claim(extra_data, key):
     return extra_data.get(key) or extra_data.get('userinfo', {}).get(key)
 
 
+USER_CONTEXT_CLAIM = 'https://www.openclinica.com/userContext'
+
+
+def _get_user_context(extra_data):
+    return _extra_data_claim(extra_data, USER_CONTEXT_CLAIM) or {}
+
+
+def _store_user_info(request, user_uuid):
+    """Store oc_user_uuid in session."""
+    if not user_uuid:
+        LOGGER.error('Empty userUuid received from access_token')
+        return
+    request.session['oc_user_uuid'] = user_uuid
+
+
+def _store_customer_info(request, access_token, customer_uuid):
+    """Store oc_customer_name and oc_customer_shared_infra from Customer API."""
+    if not customer_uuid:
+        LOGGER.error('Empty customerUuid received from access_token')
+        return
+
+    key = f'oc:customer_info:{customer_uuid}'
+    data = cache.get(key)
+    if data is None:
+        customer_url = (
+            f'{settings.OC_BUILD_URL}/customer-service'
+            f'/api/customers/{customer_uuid}'
+        )
+        headers = {'Authorization': f'Bearer {access_token}'}
+        try:
+            response = requests.get(customer_url, headers=headers, timeout=10)
+            response.raise_for_status()
+            raw = response.json()
+            data = {
+                'name': raw.get('name'),
+                'sharedInfra': raw.get('sharedInfra', False),
+            }
+            cache.set(key, data, _CACHE_TTL)
+        except Exception as exc:
+            LOGGER.error(
+                'Failed to retrieve customer info for customerUuid %s: %s',
+                customer_uuid, exc,
+            )
+            return
+
+    request.session['oc_customer_name'] = data['name']
+    request.session['oc_customer_shared_infra'] = data['sharedInfra']
+
+
+def sync_login_state(request, user, sociallogin):
+    """
+    Refreshes session/role/user_type on every login — save_user() only
+    runs on signup, so relying on it there staled these values (OC-28410).
+    """
+    subdomain = get_subdomain(request)
+    extra_data = sociallogin.account.extra_data
+    uid = sociallogin.account.uid
+    access_token = sociallogin.token.token if sociallogin.token else None
+
+    # Sync Keycloak roles → Django is_staff / is_superuser
+    from .backend import get_roles
+
+    roles = []
+    token_user_context = {}
+    if access_token:
+        try:
+            token_payload = _decode_jwt_payload(access_token)
+            roles = get_roles(token_payload)
+            token_user_context = token_payload.get(USER_CONTEXT_CLAIM) or {}
+        except Exception as exc:
+            LOGGER.warning('Failed to decode access_token: %s', exc)
+    user.is_staff = 'admin' in roles or 'superuser' in roles
+    user.is_superuser = 'superuser' in roles
+    user.save(update_fields=['is_staff', 'is_superuser'])
+
+    # Populate OC session values from access token
+    if access_token and request:
+        _store_user_info(request, token_user_context.get('userUuid'))
+        _store_customer_info(
+            request, access_token, token_user_context.get('customerUuid')
+        )
+        request.session['oc_access_token'] = access_token
+        request.session['oc_token_validated_at'] = time.time()
+        request.session['oc_fd_base_username'] = user.username.rsplit('+', 1)[0]
+
+    user_type = _get_user_context(extra_data).get('userType', '')
+
+    KeycloakTenantUser.objects.update_or_create(
+        UID=uid,
+        subdomain=subdomain,
+        defaults={'user': user, 'user_type': user_type},
+    )
+
+
 class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):
     """
     allauth SocialAccountAdapter for OpenClinica multi-tenant Keycloak OIDC.
@@ -166,97 +260,3 @@ class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):
             ea for ea in sociallogin.email_addresses
             if ea.email not in existing
         ]
-
-
-USER_CONTEXT_CLAIM = 'https://www.openclinica.com/userContext'
-
-
-def _get_user_context(extra_data):
-    return _extra_data_claim(extra_data, USER_CONTEXT_CLAIM) or {}
-
-
-def _store_user_info(request, user_uuid):
-    """Store oc_user_uuid in session."""
-    if not user_uuid:
-        LOGGER.error('Empty userUuid received from access_token')
-        return
-    request.session['oc_user_uuid'] = user_uuid
-
-
-def _store_customer_info(request, access_token, customer_uuid):
-    """Store oc_customer_name and oc_customer_shared_infra from Customer API."""
-    if not customer_uuid:
-        LOGGER.error('Empty customerUuid received from access_token')
-        return
-
-    key = f'oc:customer_info:{customer_uuid}'
-    data = cache.get(key)
-    if data is None:
-        customer_url = (
-            f'{settings.OC_BUILD_URL}/customer-service'
-            f'/api/customers/{customer_uuid}'
-        )
-        headers = {'Authorization': f'Bearer {access_token}'}
-        try:
-            response = requests.get(customer_url, headers=headers, timeout=10)
-            response.raise_for_status()
-            raw = response.json()
-            data = {
-                'name': raw.get('name'),
-                'sharedInfra': raw.get('sharedInfra', False),
-            }
-            cache.set(key, data, _CACHE_TTL)
-        except Exception as exc:
-            LOGGER.error(
-                'Failed to retrieve customer info for customerUuid %s: %s',
-                customer_uuid, exc,
-            )
-            return
-
-    request.session['oc_customer_name'] = data['name']
-    request.session['oc_customer_shared_infra'] = data['sharedInfra']
-
-
-def sync_login_state(request, user, sociallogin):
-    """
-    Refreshes session/role/user_type on every login — save_user() only
-    runs on signup, so relying on it there staled these values (OC-28410).
-    """
-    subdomain = get_subdomain(request)
-    extra_data = sociallogin.account.extra_data
-    uid = sociallogin.account.uid
-    access_token = sociallogin.token.token if sociallogin.token else None
-
-    # Sync Keycloak roles → Django is_staff / is_superuser
-    from .backend import get_roles
-
-    roles = []
-    token_user_context = {}
-    if access_token:
-        try:
-            token_payload = _decode_jwt_payload(access_token)
-            roles = get_roles(token_payload)
-            token_user_context = token_payload.get(USER_CONTEXT_CLAIM) or {}
-        except Exception as exc:
-            LOGGER.warning('Failed to decode access_token: %s', exc)
-    user.is_staff = 'admin' in roles or 'superuser' in roles
-    user.is_superuser = 'superuser' in roles
-    user.save(update_fields=['is_staff', 'is_superuser'])
-
-    # Populate OC session values from access token
-    if access_token and request:
-        _store_user_info(request, token_user_context.get('userUuid'))
-        _store_customer_info(
-            request, access_token, token_user_context.get('customerUuid')
-        )
-        request.session['oc_access_token'] = access_token
-        request.session['oc_token_validated_at'] = time.time()
-        request.session['oc_fd_base_username'] = user.username.rsplit('+', 1)[0]
-
-    user_type = _get_user_context(extra_data).get('userType', '')
-
-    KeycloakTenantUser.objects.update_or_create(
-        UID=uid,
-        subdomain=subdomain,
-        defaults={'user': user, 'user_type': user_type},
-    )

--- a/kobo/apps/oc_tenant_auth/adapter.py
+++ b/kobo/apps/oc_tenant_auth/adapter.py
@@ -46,6 +46,11 @@ def _decode_jwt_payload(token):
     return json.loads(base64.urlsafe_b64decode(part))
 
 
+def _extra_data_claim(extra_data, key):
+    """allauth extra_data claim, falling back to its nested userinfo location."""
+    return extra_data.get(key) or extra_data.get('userinfo', {}).get(key)
+
+
 class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):
     """
     allauth SocialAccountAdapter for OpenClinica multi-tenant Keycloak OIDC.
@@ -93,10 +98,8 @@ class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):
 
         # UID not found — Keycloak may have re-created the user with a new UUID.
         # Fall back to username lookup and re-key the stored UID if matched.
-        preferred_username = sociallogin.account.extra_data.get(
-            'preferred_username'
-        ) or sociallogin.account.extra_data.get('userinfo', {}).get(
-            'preferred_username'
+        preferred_username = _extra_data_claim(
+            sociallogin.account.extra_data, 'preferred_username'
         )
         if not preferred_username:
             LOGGER.error(
@@ -166,6 +169,10 @@ class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):
 
 
 USER_CONTEXT_CLAIM = 'https://www.openclinica.com/userContext'
+
+
+def _get_user_context(extra_data):
+    return _extra_data_claim(extra_data, USER_CONTEXT_CLAIM) or {}
 
 
 def _store_user_info(request, user_uuid):
@@ -246,7 +253,7 @@ def sync_login_state(request, user, sociallogin):
         request.session['oc_token_validated_at'] = time.time()
         request.session['oc_fd_base_username'] = user.username.rsplit('+', 1)[0]
 
-    user_type = extra_data.get(USER_CONTEXT_CLAIM, {}).get('userType', '')
+    user_type = _get_user_context(extra_data).get('userType', '')
 
     KeycloakTenantUser.objects.update_or_create(
         UID=uid,

--- a/kobo/apps/oc_tenant_auth/adapter.py
+++ b/kobo/apps/oc_tenant_auth/adapter.py
@@ -132,8 +132,8 @@ class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):
 
     def save_user(self, request, sociallogin, form=None):
         """
-        After user save: sync roles, populate OC session values,
-        upsert KeycloakTenantUser.
+        allauth only calls this on signup; per-login sync lives in
+        sync_login_state() instead (see signals.py).
         """
         user = super().save_user(request, sociallogin, form)
         subdomain = get_subdomain(request)
@@ -142,43 +142,7 @@ class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):
         if not user.username.endswith(f'+{subdomain}'):
             user.username = f'{user.username}+{subdomain}'
             user.save(update_fields=['username'])
-        extra_data = sociallogin.account.extra_data
-        uid = sociallogin.account.uid
-        access_token = (
-            sociallogin.token.token if sociallogin.token else None
-        )
 
-        # Sync Keycloak roles → Django is_staff / is_superuser
-        from .backend import get_roles
-
-        roles = []
-        if access_token:
-            try:
-                token_payload = _decode_jwt_payload(access_token)
-                roles = get_roles(token_payload)
-            except Exception as exc:
-                LOGGER.warning('Failed to extract roles from access_token: %s', exc)
-        user.is_staff = 'admin' in roles or 'superuser' in roles
-        user.is_superuser = 'superuser' in roles
-        user.save(update_fields=['is_staff', 'is_superuser'])
-
-        # Populate OC session values from access token
-        if access_token and request:
-            self._store_user_info(request, access_token)
-            self._store_customer_info(request, access_token)
-            request.session['oc_access_token'] = access_token
-            request.session['oc_token_validated_at'] = time.time()
-            request.session['oc_fd_base_username'] = user.username.rsplit('+', 1)[0]
-
-        user_type = extra_data.get(
-            'https://www.openclinica.com/userContext', {}
-        ).get('userType', '')
-
-        KeycloakTenantUser.objects.update_or_create(
-            UID=uid,
-            subdomain=subdomain,
-            defaults={'user': user, 'user_type': user_type},
-        )
         self._ensure_user_profile(user)
         return user
 
@@ -200,58 +164,92 @@ class TenantAwareSocialAccountAdapter(DefaultSocialAccountAdapter):
             if ea.email not in existing
         ]
 
-    def _store_user_info(self, request, access_token):
-        """Store oc_user_uuid in session from the access token userContext claim."""
-        try:
-            payload = _decode_jwt_payload(access_token)
-            user_uuid = payload.get(
-                'https://www.openclinica.com/userContext', {}
-            ).get('userUuid')
-        except Exception as exc:
-            LOGGER.error('Failed to extract userUuid from access_token: %s', exc)
-            return
-        if not user_uuid:
-            LOGGER.error('Empty userUuid received from access_token')
-            return
-        request.session['oc_user_uuid'] = user_uuid
 
-    def _store_customer_info(self, request, access_token):
-        """Store oc_customer_name and oc_customer_shared_infra from Customer API."""
-        try:
-            payload = _decode_jwt_payload(access_token)
-            customer_uuid = payload.get(
-                'https://www.openclinica.com/userContext', {}
-            ).get('customerUuid')
-        except Exception as exc:
-            LOGGER.error('Failed to extract customerUuid from access_token: %s', exc)
-            return
-        if not customer_uuid:
-            LOGGER.error('Empty customerUuid received from access_token')
-            return
+USER_CONTEXT_CLAIM = 'https://www.openclinica.com/userContext'
 
-        key = f'oc:customer_info:{customer_uuid}'
-        data = cache.get(key)
-        if data is None:
-            customer_url = (
-                f'{settings.OC_BUILD_URL}/customer-service'
-                f'/api/customers/{customer_uuid}'
+
+def _store_user_info(request, user_uuid):
+    """Store oc_user_uuid in session."""
+    if not user_uuid:
+        LOGGER.error('Empty userUuid received from access_token')
+        return
+    request.session['oc_user_uuid'] = user_uuid
+
+
+def _store_customer_info(request, access_token, customer_uuid):
+    """Store oc_customer_name and oc_customer_shared_infra from Customer API."""
+    if not customer_uuid:
+        LOGGER.error('Empty customerUuid received from access_token')
+        return
+
+    key = f'oc:customer_info:{customer_uuid}'
+    data = cache.get(key)
+    if data is None:
+        customer_url = (
+            f'{settings.OC_BUILD_URL}/customer-service'
+            f'/api/customers/{customer_uuid}'
+        )
+        headers = {'Authorization': f'Bearer {access_token}'}
+        try:
+            response = requests.get(customer_url, headers=headers, timeout=10)
+            response.raise_for_status()
+            raw = response.json()
+            data = {
+                'name': raw.get('name'),
+                'sharedInfra': raw.get('sharedInfra', False),
+            }
+            cache.set(key, data, _CACHE_TTL)
+        except Exception as exc:
+            LOGGER.error(
+                'Failed to retrieve customer info for customerUuid %s: %s',
+                customer_uuid, exc,
             )
-            headers = {'Authorization': f'Bearer {access_token}'}
-            try:
-                response = requests.get(customer_url, headers=headers, timeout=10)
-                response.raise_for_status()
-                raw = response.json()
-                data = {
-                    'name': raw.get('name'),
-                    'sharedInfra': raw.get('sharedInfra', False),
-                }
-                cache.set(key, data, _CACHE_TTL)
-            except Exception as exc:
-                LOGGER.error(
-                    'Failed to retrieve customer info for customerUuid %s: %s',
-                    customer_uuid, exc,
-                )
-                return
+            return
 
-        request.session['oc_customer_name'] = data['name']
-        request.session['oc_customer_shared_infra'] = data['sharedInfra']
+    request.session['oc_customer_name'] = data['name']
+    request.session['oc_customer_shared_infra'] = data['sharedInfra']
+
+
+def sync_login_state(request, user, sociallogin):
+    """
+    Refreshes session/role/user_type on every login — save_user() only
+    runs on signup, so relying on it there staled these values (OC-28410).
+    """
+    subdomain = get_subdomain(request)
+    extra_data = sociallogin.account.extra_data
+    uid = sociallogin.account.uid
+    access_token = sociallogin.token.token if sociallogin.token else None
+
+    # Sync Keycloak roles → Django is_staff / is_superuser
+    from .backend import get_roles
+
+    roles = []
+    token_user_context = {}
+    if access_token:
+        try:
+            token_payload = _decode_jwt_payload(access_token)
+            roles = get_roles(token_payload)
+            token_user_context = token_payload.get(USER_CONTEXT_CLAIM, {})
+        except Exception as exc:
+            LOGGER.warning('Failed to decode access_token: %s', exc)
+    user.is_staff = 'admin' in roles or 'superuser' in roles
+    user.is_superuser = 'superuser' in roles
+    user.save(update_fields=['is_staff', 'is_superuser'])
+
+    # Populate OC session values from access token
+    if access_token and request:
+        _store_user_info(request, token_user_context.get('userUuid'))
+        _store_customer_info(
+            request, access_token, token_user_context.get('customerUuid')
+        )
+        request.session['oc_access_token'] = access_token
+        request.session['oc_token_validated_at'] = time.time()
+        request.session['oc_fd_base_username'] = user.username.rsplit('+', 1)[0]
+
+    user_type = extra_data.get(USER_CONTEXT_CLAIM, {}).get('userType', '')
+
+    KeycloakTenantUser.objects.update_or_create(
+        UID=uid,
+        subdomain=subdomain,
+        defaults={'user': user, 'user_type': user_type},
+    )

--- a/kobo/apps/oc_tenant_auth/adapter.py
+++ b/kobo/apps/oc_tenant_auth/adapter.py
@@ -236,7 +236,7 @@ def sync_login_state(request, user, sociallogin):
         try:
             token_payload = _decode_jwt_payload(access_token)
             roles = get_roles(token_payload)
-            token_user_context = token_payload.get(USER_CONTEXT_CLAIM, {})
+            token_user_context = token_payload.get(USER_CONTEXT_CLAIM) or {}
         except Exception as exc:
             LOGGER.warning('Failed to decode access_token: %s', exc)
     user.is_staff = 'admin' in roles or 'superuser' in roles

--- a/kobo/apps/oc_tenant_auth/apps.py
+++ b/kobo/apps/oc_tenant_auth/apps.py
@@ -5,3 +5,9 @@ class TenantAuthConfig(AppConfig):
     name = 'kobo.apps.oc_tenant_auth'
     label = 'oc_tenant_auth'
     verbose_name = 'Tenant Authentication'
+
+    def ready(self):
+        # Makes sure signal handlers are connected
+        import kobo.apps.oc_tenant_auth.signals  # noqa
+
+        super().ready()

--- a/kobo/apps/oc_tenant_auth/signals.py
+++ b/kobo/apps/oc_tenant_auth/signals.py
@@ -1,0 +1,15 @@
+from allauth.account.signals import user_logged_in
+from django.dispatch import receiver
+
+from .adapter import sync_login_state
+
+
+@receiver(user_logged_in, dispatch_uid='oc_tenant_auth.sync_login_state')
+def refresh_login_state(sender, request, user, sociallogin=None, **kwargs):
+    """
+    Runs on every login, unlike save_user() (signup only, OC-28410).
+    Skips non-social logins, which have no sociallogin in signal_kwargs.
+    """
+    if sociallogin is None:
+        return
+    sync_login_state(request, user, sociallogin)

--- a/kobo/apps/oc_tenant_auth/signals.py
+++ b/kobo/apps/oc_tenant_auth/signals.py
@@ -1,7 +1,11 @@
+import logging
+
 from allauth.account.signals import user_logged_in
 from django.dispatch import receiver
 
 from .adapter import sync_login_state
+
+LOGGER = logging.getLogger(__name__)
 
 
 @receiver(user_logged_in, dispatch_uid='oc_tenant_auth.sync_login_state')
@@ -11,5 +15,8 @@ def refresh_login_state(sender, request, user, sociallogin=None, **kwargs):
     Skips non-social logins, which have no sociallogin in signal_kwargs.
     """
     if sociallogin is None:
+        LOGGER.debug(
+            'Skipping sync_login_state for user %s: non-social login', user.pk,
+        )
         return
     sync_login_state(request, user, sociallogin)

--- a/kobo/apps/oc_tenant_auth/tests/test_adapter.py
+++ b/kobo/apps/oc_tenant_auth/tests/test_adapter.py
@@ -139,3 +139,27 @@ class SyncLoginStateTestCase(TestCase):
             side_effect=Exception('boom'),
         ):
             sync_login_state(self.request, self.user, self.sociallogin)
+
+    def test_customer_service_request_failure_does_not_raise(
+        self, mock_get, mock_subdomain
+    ):
+        mock_get.side_effect = ConnectionError('customer-service unreachable')
+
+        sync_login_state(self.request, self.user, self.sociallogin)
+
+        self.assertNotIn('oc_customer_shared_infra', self.request.session)
+        kc_user = KeycloakTenantUser.objects.get(UID='kc-uid-1')
+        self.assertEqual(kc_user.user_type, 'Business Admin')
+
+    def test_demotes_stale_admin_role_on_next_login(self, mock_get, mock_subdomain):
+        self._mock_customer_response(mock_get, True)
+        self.user.is_staff = True
+        self.user.is_superuser = True
+        self.user.save()
+
+        # realm_access.roles is [] in setUp — Keycloak no longer grants admin.
+        sync_login_state(self.request, self.user, self.sociallogin)
+
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_staff)
+        self.assertFalse(self.user.is_superuser)

--- a/kobo/apps/oc_tenant_auth/tests/test_adapter.py
+++ b/kobo/apps/oc_tenant_auth/tests/test_adapter.py
@@ -88,3 +88,17 @@ class SyncLoginStateTestCase(TestCase):
 
         self.assertTrue(KeycloakTenantUser.objects.filter(UID='kc-uid-1').exists())
         self.assertIs(self.request.session['oc_customer_shared_infra'], False)
+
+    def test_reads_user_type_from_nested_userinfo_claim(self, mock_get, mock_subdomain):
+        # Real Keycloak responses nest userContext under extra_data['userinfo'].
+        self._mock_customer_response(mock_get, True)
+        self.sociallogin.account.extra_data = {
+            'userinfo': {
+                'https://www.openclinica.com/userContext': {'userType': 'Business Admin'},
+            },
+        }
+
+        sync_login_state(self.request, self.user, self.sociallogin)
+
+        kc_user = KeycloakTenantUser.objects.get(UID='kc-uid-1')
+        self.assertEqual(kc_user.user_type, 'Business Admin')

--- a/kobo/apps/oc_tenant_auth/tests/test_adapter.py
+++ b/kobo/apps/oc_tenant_auth/tests/test_adapter.py
@@ -78,8 +78,14 @@ class SyncLoginStateTestCase(TestCase):
         self.assertIs(self.request.session['oc_customer_shared_infra'], True)
         kc_user = KeycloakTenantUser.objects.get(UID='kc-uid-1')
         self.assertEqual(kc_user.user_type, 'Business Admin')
+        self.assertEqual(
+            mock_get.call_args.kwargs['headers']['Authorization'],
+            f'Bearer {self.access_token}',
+        )
 
-    def test_creates_keycloak_tenant_user_on_first_login(self, mock_get, mock_subdomain):
+    def test_creates_keycloak_tenant_user_on_first_login(
+        self, mock_get, mock_subdomain
+    ):
         self._mock_customer_response(mock_get, False)
 
         self.assertFalse(KeycloakTenantUser.objects.filter(UID='kc-uid-1').exists())
@@ -89,12 +95,16 @@ class SyncLoginStateTestCase(TestCase):
         self.assertTrue(KeycloakTenantUser.objects.filter(UID='kc-uid-1').exists())
         self.assertIs(self.request.session['oc_customer_shared_infra'], False)
 
-    def test_reads_user_type_from_nested_userinfo_claim(self, mock_get, mock_subdomain):
+    def test_reads_user_type_from_nested_userinfo_claim(
+        self, mock_get, mock_subdomain
+    ):
         # Real Keycloak responses nest userContext under extra_data['userinfo'].
         self._mock_customer_response(mock_get, True)
         self.sociallogin.account.extra_data = {
             'userinfo': {
-                'https://www.openclinica.com/userContext': {'userType': 'Business Admin'},
+                'https://www.openclinica.com/userContext': {
+                    'userType': 'Business Admin',
+                },
             },
         }
 
@@ -103,7 +113,9 @@ class SyncLoginStateTestCase(TestCase):
         kc_user = KeycloakTenantUser.objects.get(UID='kc-uid-1')
         self.assertEqual(kc_user.user_type, 'Business Admin')
 
-    def test_handles_null_user_context_claim_without_raising(self, mock_get, mock_subdomain):
+    def test_handles_null_user_context_claim_without_raising(
+        self, mock_get, mock_subdomain
+    ):
         # A userContext claim present but set to null must not crash login.
         self._mock_customer_response(mock_get, True)
         self.sociallogin.token.token = _make_jwt({

--- a/kobo/apps/oc_tenant_auth/tests/test_adapter.py
+++ b/kobo/apps/oc_tenant_auth/tests/test_adapter.py
@@ -1,0 +1,90 @@
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase
+from model_bakery import baker
+
+from kobo.apps.oc_tenant_auth.adapter import sync_login_state
+from kobo.apps.oc_tenant_auth.models import KeycloakTenantUser
+
+
+def _make_jwt(payload):
+    def _b64url(data):
+        return base64.urlsafe_b64encode(data).rstrip(b'=').decode()
+
+    header = _b64url(b'{"alg":"none"}')
+    body = _b64url(json.dumps(payload).encode())
+    return f'{header}.{body}.sig'
+
+
+@patch('kobo.apps.oc_tenant_auth.adapter.get_subdomain', return_value='demo')
+@patch('kobo.apps.oc_tenant_auth.adapter.requests.get')
+class SyncLoginStateTestCase(TestCase):
+    """
+    Regression coverage for OC-28410: returning logins must refresh
+    customer_shared_infra/user_type, not just first-ever signup.
+    """
+
+    def setUp(self):
+        # Real cache backend persists across tests; clear it so one test's
+        # cached customer_uuid response can't leak into another's.
+        cache.clear()
+
+        self.user = baker.make(settings.AUTH_USER_MODEL, username='alice+demo')
+
+        request = RequestFactory().get('/')
+        SessionMiddleware(lambda r: None).process_request(request)
+        request.session.save()
+        self.request = request
+
+        self.access_token = _make_jwt({
+            'https://www.openclinica.com/userContext': {
+                'userUuid': 'user-uuid-1',
+                'customerUuid': 'customer-uuid-1',
+            },
+            'realm_access': {'roles': []},
+        })
+
+        self.sociallogin = MagicMock()
+        self.sociallogin.account.uid = 'kc-uid-1'
+        self.sociallogin.account.extra_data = {
+            'https://www.openclinica.com/userContext': {'userType': 'Business Admin'},
+        }
+        self.sociallogin.token.token = self.access_token
+
+    def _mock_customer_response(self, mock_get, shared_infra):
+        mock_get.return_value = MagicMock(
+            json=lambda: {'name': 'Acme', 'sharedInfra': shared_infra},
+        )
+        mock_get.return_value.raise_for_status.return_value = None
+
+    def test_refreshes_shared_infra_and_user_type_on_returning_login(
+        self, mock_get, mock_subdomain
+    ):
+        self._mock_customer_response(mock_get, True)
+
+        # Returning login: row already exists with stale data save_user()
+        # never revisits.
+        KeycloakTenantUser.objects.create(
+            UID='kc-uid-1', user=self.user, subdomain='demo', user_type='Standard',
+        )
+
+        sync_login_state(self.request, self.user, self.sociallogin)
+
+        self.assertIs(self.request.session['oc_customer_shared_infra'], True)
+        kc_user = KeycloakTenantUser.objects.get(UID='kc-uid-1')
+        self.assertEqual(kc_user.user_type, 'Business Admin')
+
+    def test_creates_keycloak_tenant_user_on_first_login(self, mock_get, mock_subdomain):
+        self._mock_customer_response(mock_get, False)
+
+        self.assertFalse(KeycloakTenantUser.objects.filter(UID='kc-uid-1').exists())
+
+        sync_login_state(self.request, self.user, self.sociallogin)
+
+        self.assertTrue(KeycloakTenantUser.objects.filter(UID='kc-uid-1').exists())
+        self.assertIs(self.request.session['oc_customer_shared_infra'], False)

--- a/kobo/apps/oc_tenant_auth/tests/test_adapter.py
+++ b/kobo/apps/oc_tenant_auth/tests/test_adapter.py
@@ -126,3 +126,16 @@ class SyncLoginStateTestCase(TestCase):
         sync_login_state(self.request, self.user, self.sociallogin)
 
         self.assertNotIn('oc_customer_shared_infra', self.request.session)
+
+    def test_swallows_unexpected_failure_instead_of_raising(
+        self, mock_get, mock_subdomain
+    ):
+        # A crash here must not propagate: user_logged_in.send() would
+        # otherwise block login for every existing user, not just this one.
+        self._mock_customer_response(mock_get, True)
+        with patch(
+            'kobo.apps.oc_tenant_auth.adapter.KeycloakTenantUser.objects.'
+            'update_or_create',
+            side_effect=Exception('boom'),
+        ):
+            sync_login_state(self.request, self.user, self.sociallogin)

--- a/kobo/apps/oc_tenant_auth/tests/test_adapter.py
+++ b/kobo/apps/oc_tenant_auth/tests/test_adapter.py
@@ -102,3 +102,15 @@ class SyncLoginStateTestCase(TestCase):
 
         kc_user = KeycloakTenantUser.objects.get(UID='kc-uid-1')
         self.assertEqual(kc_user.user_type, 'Business Admin')
+
+    def test_handles_null_user_context_claim_without_raising(self, mock_get, mock_subdomain):
+        # A userContext claim present but set to null must not crash login.
+        self._mock_customer_response(mock_get, True)
+        self.sociallogin.token.token = _make_jwt({
+            'https://www.openclinica.com/userContext': None,
+            'realm_access': {'roles': []},
+        })
+
+        sync_login_state(self.request, self.user, self.sociallogin)
+
+        self.assertNotIn('oc_customer_shared_infra', self.request.session)

--- a/kobo/apps/oc_tenant_auth/tests/test_signals.py
+++ b/kobo/apps/oc_tenant_auth/tests/test_signals.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+from django.test import RequestFactory, TestCase
+from model_bakery import baker
+
+from kobo.apps.oc_tenant_auth.signals import refresh_login_state
+
+
+class RefreshLoginStateTestCase(TestCase):
+    def setUp(self):
+        self.user = baker.make(settings.AUTH_USER_MODEL)
+        self.request = RequestFactory().get('/')
+
+    @patch('kobo.apps.oc_tenant_auth.signals.sync_login_state')
+    def test_syncs_on_social_login(self, mock_sync):
+        sociallogin = MagicMock()
+        refresh_login_state(
+            sender=self.user.__class__,
+            request=self.request,
+            user=self.user,
+            sociallogin=sociallogin,
+        )
+        mock_sync.assert_called_once_with(self.request, self.user, sociallogin)
+
+    @patch('kobo.apps.oc_tenant_auth.signals.sync_login_state')
+    def test_ignores_non_social_login(self, mock_sync):
+        # e.g. Django admin password login — no sociallogin in signal_kwargs
+        refresh_login_state(
+            sender=self.user.__class__, request=self.request, user=self.user,
+        )
+        mock_sync.assert_not_called()


### PR DESCRIPTION
## Summary
- Fixes OC-28410: non-admin users on EDC Self Service tenants could see the "add to library" buttons in the Form Builder. Root cause: allauth's `SocialAccountAdapter.save_user()` only runs on first-ever signup, so `customer_shared_infra` and `user_type` were populated once and never refreshed on later logins.
- Adds a `user_logged_in` signal receiver (`sync_login_state()` in `signals.py`) that runs this sync on every login, not just signup.
- Also fixes an unrelated bug found while testing this: `user_type` was read from the wrong location in `extra_data` (top level instead of nested under `userinfo`), so it was always blank regardless of the fix above. Generalized the same fallback already used for `preferred_username` in `pre_social_login`.

## Test plan
- Added `kobo/apps/oc_tenant_auth/tests/` (no prior test coverage existed for this app) covering: returning-login refresh, first-login creation, and the nested-userinfo claim fallback.
- Manually verified against a local deploy: a non-admin user's "add to library" buttons are correctly hidden after a second login on a self-service tenant, admin behavior unaffected.