### PR TITLE
Jenkinsfile: bind the GitHub credential as usernamePassword

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,9 +47,12 @@ pipeline {
                 // The credential is a Username-with-password (username + GitHub token),
                 // so bind it with usernamePassword — a string() binding fails with
                 // "is of type 'Username with password' where StringCredentials was
-                // expected". Single-quoted sh body -> ${GH_USER}/${GH_TOKEN} expand in
-                // the shell from the masked credential env vars, never in Groovy (so
-                // they aren't logged).
+                // expected". usernameVariable is a required parameter of the binding;
+                // GH_USER is intentionally unused (masked, stage-scoped) — the URL uses
+                // the fixed x-access-token username so an empty/misconfigured stored
+                // username can't break auth (GitHub ignores the username for PATs).
+                // Single-quoted sh body -> ${GH_TOKEN} expands in the shell from the
+                // masked credential env var, never in Groovy (so it isn't logged).
                 withCredentials([usernamePassword(credentialsId: 'jenkins-github-token-as-password', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
                     sh '''
                         set -e
@@ -63,7 +66,7 @@ pipeline {
                         # wipes it on exit, success or failure.
                         export GIT_CONFIG_GLOBAL="$(mktemp)"
                         trap 'rm -f "$GIT_CONFIG_GLOBAL"' EXIT
-                        git config --global url."https://${GH_USER}:${GH_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+                        git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
                         npm ci --legacy-peer-deps --cache /tmp/.npm-cache
                         npm run test:unit
                     '''
@@ -104,8 +107,10 @@ pipeline {
                     // @openclinica/logic-builder (id must match the Dockerfile's
                     // `--mount=type=secret,id=gh_token`). The credential is a
                     // Username-with-password, so bind with usernamePassword and feed
-                    // the password component (the token) to BuildKit; `env=GH_TOKEN`
+                    // only the password component (the token) to BuildKit; `env=GH_TOKEN`
                     // reads the masked env var, so it never appears in the log.
+                    // usernameVariable is required by the binding — GH_USER is unused
+                    // here (the Dockerfile authenticates as x-access-token).
                     withCredentials([usernamePassword(credentialsId: 'jenkins-github-token-as-password', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
                         sh "docker buildx build --builder arm64builder --platform linux/aarch64 --secret id=gh_token,env=GH_TOKEN -t ${registry}:${tag_version} --push ."
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,9 +44,13 @@ pipeline {
             }
             steps {
                 // OC fork: authenticate the private @openclinica/logic-builder clone.
-                // Single-quoted sh body -> ${GH_TOKEN} expands in the shell from the
-                // masked credential env var, never in Groovy (so it isn't logged).
-                withCredentials([string(credentialsId: 'jenkins-github-token-as-password', variable: 'GH_TOKEN')]) {
+                // The credential is a Username-with-password (username + GitHub token),
+                // so bind it with usernamePassword — a string() binding fails with
+                // "is of type 'Username with password' where StringCredentials was
+                // expected". Single-quoted sh body -> ${GH_USER}/${GH_TOKEN} expand in
+                // the shell from the masked credential env vars, never in Groovy (so
+                // they aren't logged).
+                withCredentials([usernamePassword(credentialsId: 'jenkins-github-token-as-password', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
                     sh '''
                         set -e
                         apt-get update -qq
@@ -59,7 +63,7 @@ pipeline {
                         # wipes it on exit, success or failure.
                         export GIT_CONFIG_GLOBAL="$(mktemp)"
                         trap 'rm -f "$GIT_CONFIG_GLOBAL"' EXIT
-                        git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+                        git config --global url."https://${GH_USER}:${GH_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
                         npm ci --legacy-peer-deps --cache /tmp/.npm-cache
                         npm run test:unit
                     '''
@@ -98,9 +102,11 @@ pipeline {
                     // OC fork: pass the GitHub token to BuildKit as a secret so the
                     // Dockerfile's npm-install stage can clone the private
                     // @openclinica/logic-builder (id must match the Dockerfile's
-                    // `--mount=type=secret,id=gh_token`). `env=GH_TOKEN` reads it from
-                    // the masked credential env var, so it never appears in the log.
-                    withCredentials([string(credentialsId: 'jenkins-github-token-as-password', variable: 'GH_TOKEN')]) {
+                    // `--mount=type=secret,id=gh_token`). The credential is a
+                    // Username-with-password, so bind with usernamePassword and feed
+                    // the password component (the token) to BuildKit; `env=GH_TOKEN`
+                    // reads the masked env var, so it never appears in the log.
+                    withCredentials([usernamePassword(credentialsId: 'jenkins-github-token-as-password', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
                         sh "docker buildx build --builder arm64builder --platform linux/aarch64 --secret id=gh_token,env=GH_TOKEN -t ${registry}:${tag_version} --push ."
                     }
                   }


### PR DESCRIPTION
jenkins-github-token-as-password is a Username-with-password credential, so the string() binding failed with "is of type 'Username with password' where StringCredentials was expected". Bind username + token explicitly; the test stage uses both in the insteadOf URL and the image build still feeds only the token to BuildKit.

### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

TODO

### 📖 Description
<!-- Delete this section if summary already said everything. -->
<!-- Full description for the public changelog, worded for non-technical seasoned Kobo users. -->

TODO

### 👷 Description for instance maintainers
<!-- Delete this section if everything is already said above. -->
<!-- Full description for the public changelog, worded for technical Kobo instance maintainers. -->

TODO

### 💭 Notes
<!-- Delete this section if empty. -->
<!-- Anything else useful that's not said above,worded for
reviewers, testers, and future git archaeologist collegues. Examples:
- screenshots, copy-pasted logs, etc.
- what was tried but didn't work,
- conscious short-term vs long-term tradeoffs,
- proactively answer likely questions,
-->

TODO

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
