### PR TITLE
OC-28430: fix library search box missing in Study Designer

### DIFF
--- a/jsapp/js/router/routerUtils.tests.ts
+++ b/jsapp/js/router/routerUtils.tests.ts
@@ -1,5 +1,11 @@
 import chai from 'chai'
-import { getCurrentPath, getCurrentRoutePath, getLoginUrl, isMyLibraryRoute, isPublicCollectionsRoute } from './routerUtils'
+import {
+  getCurrentPath,
+  getCurrentRoutePath,
+  getLoginUrl,
+  isMyLibraryRoute,
+  isPublicCollectionsRoute,
+} from './routerUtils'
 
 function setHash(hash: string) {
   Object.defineProperty(window, 'location', {

--- a/jsapp/js/router/routerUtils.tests.ts
+++ b/jsapp/js/router/routerUtils.tests.ts
@@ -1,0 +1,101 @@
+import chai from 'chai'
+import { getCurrentPath, getCurrentRoutePath, getLoginUrl, isMyLibraryRoute, isPublicCollectionsRoute } from './routerUtils'
+
+function setHash(hash: string) {
+  Object.defineProperty(window, 'location', {
+    value: { hash },
+    writable: true,
+    configurable: true,
+  })
+}
+
+describe('routerUtils', () => {
+  describe('getCurrentPath', () => {
+    it('returns path with query string intact', () => {
+      setHash('#/library/my-library?search=foo')
+      chai.expect(getCurrentPath()).to.equal('/library/my-library?search=foo')
+    })
+
+    it('returns path without query string when none present', () => {
+      setHash('#/library/my-library')
+      chai.expect(getCurrentPath()).to.equal('/library/my-library')
+    })
+
+    it('returns empty string when no hash fragment', () => {
+      setHash('')
+      chai.expect(getCurrentPath()).to.equal('')
+    })
+
+    it('preserves econsent query param', () => {
+      setHash('#/library/asset/new?econsent=ACTIVE&event_type=NONREPEATING_VISIT')
+      chai.expect(getCurrentPath()).to.equal('/library/asset/new?econsent=ACTIVE&event_type=NONREPEATING_VISIT')
+    })
+  })
+
+  describe('getCurrentRoutePath', () => {
+    it('strips query string for route matching', () => {
+      setHash('#/library/my-library?search=foo')
+      chai.expect(getCurrentRoutePath()).to.equal('/library/my-library')
+    })
+
+    it('returns path unchanged when no query string', () => {
+      setHash('#/library/my-library')
+      chai.expect(getCurrentRoutePath()).to.equal('/library/my-library')
+    })
+
+    it('strips econsent param', () => {
+      setHash('#/library/asset/new?econsent=ACTIVE')
+      chai.expect(getCurrentRoutePath()).to.equal('/library/asset/new')
+    })
+  })
+
+  describe('getLoginUrl', () => {
+    it('encodes full path including query string into next param', () => {
+      setHash('#/library/asset/new?econsent=ACTIVE&event_type=NONREPEATING_VISIT')
+      const url = getLoginUrl()
+      const next = new URLSearchParams(url.split('?')[1]).get('next')
+      chai.expect(next).to.equal('/#/library/asset/new?econsent=ACTIVE&event_type=NONREPEATING_VISIT')
+    })
+
+    it('returns login url with next param for plain path', () => {
+      setHash('#/forms/aAbBcC123')
+      const url = getLoginUrl()
+      chai.expect(url).to.include('next=')
+      chai.expect(url).to.include(encodeURIComponent('/#/forms/aAbBcC123'))
+    })
+  })
+
+  describe('isMyLibraryRoute', () => {
+    it('returns true when on my-library route without query string', () => {
+      setHash('#/library/my-library')
+      chai.expect(isMyLibraryRoute()).to.equal(true)
+    })
+
+    it('returns true when on my-library route with search query string', () => {
+      setHash('#/library/my-library?search=glucose+tolerance')
+      chai.expect(isMyLibraryRoute()).to.equal(true)
+    })
+
+    it('returns false for other library routes', () => {
+      setHash('#/library/public-collections')
+      chai.expect(isMyLibraryRoute()).to.equal(false)
+    })
+  })
+
+  describe('isPublicCollectionsRoute', () => {
+    it('returns true when on public-collections route without query string', () => {
+      setHash('#/library/public-collections')
+      chai.expect(isPublicCollectionsRoute()).to.equal(true)
+    })
+
+    it('returns true when on public-collections route with query string', () => {
+      setHash('#/library/public-collections?search=foo')
+      chai.expect(isPublicCollectionsRoute()).to.equal(true)
+    })
+
+    it('returns false for my-library route', () => {
+      setHash('#/library/my-library')
+      chai.expect(isPublicCollectionsRoute()).to.equal(false)
+    })
+  })
+})

--- a/jsapp/js/router/routerUtils.ts
+++ b/jsapp/js/router/routerUtils.ts
@@ -36,7 +36,9 @@ export function redirectToLogin() {
 
 export function getCurrentPath(): string {
   const route = location.hash.split('#')
-  return route.length > 1 ? route[1] : ''
+  // Strip query string so path comparisons (isMyLibraryRoute etc.) work correctly
+  // even when a query param (e.g. ?econsent=ACTIVE) is present in the hash.
+  return route.length > 1 ? route[1].split('?')[0] : ''
 }
 
 /**

--- a/jsapp/js/router/routerUtils.ts
+++ b/jsapp/js/router/routerUtils.ts
@@ -36,9 +36,18 @@ export function redirectToLogin() {
 
 export function getCurrentPath(): string {
   const route = location.hash.split('#')
-  // Strip query string so path comparisons (isMyLibraryRoute etc.) work correctly
-  // even when a query param (e.g. ?econsent=ACTIVE) is present in the hash.
-  return route.length > 1 ? route[1].split('?')[0] : ''
+  return route.length > 1 ? route[1] : ''
+}
+
+/**
+ * Like `getCurrentPath()` but strips the hash query string.
+ * Use this for exact route equality checks (e.g. isMyLibraryRoute) where a
+ * query param such as `?search=...` must not prevent a match.
+ * Do NOT use this for getLoginUrl() — the full path including query params must
+ * be preserved in the `next=` redirect so params like `econsent` survive login.
+ */
+export function getCurrentRoutePath(): string {
+  return getCurrentPath().split('?')[0]
 }
 
 /**
@@ -70,11 +79,11 @@ export function isLibraryRoute(): boolean {
 }
 
 export function isMyLibraryRoute(): boolean {
-  return getCurrentPath() === ROUTES.MY_LIBRARY
+  return getCurrentRoutePath() === ROUTES.MY_LIBRARY
 }
 
 export function isPublicCollectionsRoute(): boolean {
-  return getCurrentPath() === ROUTES.PUBLIC_COLLECTIONS
+  return getCurrentRoutePath() === ROUTES.PUBLIC_COLLECTIONS
 }
 
 export function isNewLibraryItemRoute(): boolean {


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Bug fix for missing search box in Library in Study Designer (dev). Root cause: OC-27826 upgrade replaced header.es6 (used startsWith) with mainHeader.component.tsx (uses strict ===). Dev appends ?econsent=ACTIVE to the library URL hash, which caused the route check to fail, hiding the search box. Fix strips the query string from the hash path before comparison in getCurrentPath() (routerUtils.ts).

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
