### PR TITLE
OC-28436: Remove required-question asterisk to match prod look

### DIFF
--- a/jsapp/scss/stylesheets/partials/form_builder/_card.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card.scss
@@ -138,27 +138,6 @@
     &.card--shaded .card__header-title {
         opacity: 0.3;
     }
-
-    &--required {
-        .card__text::after {
-            content: '*';
-            position: absolute;
-            top: -0.15em;
-            left: -9px;
-            color: colors.$kobo-gray-700;
-            font-size: 11px;
-        }
-
-        &.card--selectquestion {
-            .card__text {
-                padding-left: 10px;
-
-                &::after {
-                    left: 1px;
-                }
-            }
-        }
-    }
 }
 
 // pseudo-rule used only to increase card hover area to the left of the card


### PR DESCRIPTION
## Summary
- The OC-27826 kpi/kobo upgrade (2.026.12i) brought in upstream's `.card--required` asterisk indicator for required questions in Form Designer, which was never visible in OC's prior kpi fork.
- Removes the `&--required` CSS block (and its `.card--selectquestion` positioning override) from `_card.scss` so required questions render without an asterisk, matching production behavior.

## Test plan
- [x] Rebuilt kpi frontend in-container (`npm run build:app` + `collectstatic`)
- [x] In Form Designer, set a question's Required to "Always", saved, reloaded
- [x] Confirmed `.card--required` class is applied to the question card but no asterisk renders (verified via DOM `getComputedStyle` and screenshot)
- [x] Reverted the test question back to its original state