### PR TITLE
OC-28363: add repeat type to appearance panel render

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -1145,6 +1145,7 @@ module.exports = do ->
       audio:           audio
       video:           video
       group:           group
+      repeat:          group
       text:            text
       file:            file
       note:            note

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -42,7 +42,7 @@ module.exports = do ->
       return { card: 'custom', columnCount: null, customText: cleaned }
 
     # Group-specific card grid (no Custom card; unknown values default to standard-group)
-    if questionType is 'group'
+    if questionType in ['group', 'repeat']
       if cleaned is 'table-list'
         return { card: 'table-list', columnCount: null, customText: null }
       if cleaned is 'field-list'
@@ -1220,7 +1220,7 @@ module.exports = do ->
 
   viewRowDetail.DetailViewMixins.appearance =
     isCardGridType: ->
-      @model_type() in ['select_one', 'select_multiple', 'date', 'note', 'file', 'text', 'audio', 'video', 'group']
+      @model_type() in ['select_one', 'select_multiple', 'date', 'note', 'file', 'text', 'audio', 'video', 'group', 'repeat']
 
     getTypes: ->
       types =
@@ -1334,7 +1334,7 @@ module.exports = do ->
         # Switching TO grid — render the sections.
         # Use get_width_token_from_model_value (not get_width_from_model_value) to
         # preserve out-of-range tokens like w14 from migrated 3.x forms (OC-28306).
-        if questionType is 'group'
+        if questionType in ['group', 'repeat']
           @_afterRenderGroupCols(@get_width_token_from_model_value())
         else
           @_afterRenderWidth()
@@ -1342,7 +1342,7 @@ module.exports = do ->
         # Switching AWAY from grid — remove the sections immediately.
         # Selectors below must stay in sync with those used by _afterRenderGroupCols
         # and _afterRenderWidth; if either changes its wrapper class, update here too.
-        if questionType is 'group'
+        if questionType in ['group', 'repeat']
           @rowView.cardSettingsWrap.find('.js-group-cols-wrap').remove()
         else
           @rowView.cardSettingsWrap.find('.js-item-width-wrap').remove()
@@ -1381,7 +1381,7 @@ module.exports = do ->
           </div>
         """
       gridClass = 'card__settings__appearance-grid'
-      gridClass += ' card__settings__appearance-grid--group' if questionType is 'group'
+      gridClass += ' card__settings__appearance-grid--group' if questionType in ['group', 'repeat']
       @$el.append($('<div/>', { class: gridClass }).html(cardHtml))
 
       # Render secondary control for initial state
@@ -1405,7 +1405,7 @@ module.exports = do ->
           selectCard(evt.currentTarget)
 
       # For groups: Columns in Grid as own section after Appearance; for non-groups: item width picker
-      if questionType is 'group'
+      if questionType in ['group', 'repeat']
         @_afterRenderGroupCols(@get_width_token_from_model_value())
       else
         @_afterRenderWidth()

--- a/test/xlform/viewRowDetail.tests.coffee
+++ b/test/xlform/viewRowDetail.tests.coffee
@@ -1083,3 +1083,116 @@ do ->
       @ctx.model_type = -> 'group'
       @mixin.onOcFormStyleChange.call(@ctx)
       expect(@cardSettingsWrap.find('.js-group-cols-wrap').length).toBe(0)
+
+    it 'switching TO grid on a repeat calls _afterRenderGroupCols', ->
+      groupColsCalled = false
+      @ctx.is_form_style_theme_grid = -> true
+      @ctx.model_type = -> 'repeat'
+      @ctx._afterRenderGroupCols = -> groupColsCalled = true
+      @mixin.onOcFormStyleChange.call(@ctx)
+      expect(groupColsCalled).toBe(true)
+
+    it 'switching AWAY from grid on a repeat removes .js-group-cols-wrap', ->
+      @ctx.is_form_style_theme_grid = -> false
+      @ctx.model_type = -> 'repeat'
+      @mixin.onOcFormStyleChange.call(@ctx)
+      expect(@cardSettingsWrap.find('.js-group-cols-wrap').length).toBe(0)
+
+  ###############################################################
+  # view.rowDetail: parseAppearanceValue — repeat type
+  ###############################################################
+  describe 'view.rowDetail: parseAppearanceValue() with repeat type', ->
+    beforeEach ->
+      @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      @parse = @viewRowDetail.parseAppearanceValue
+
+    it 'defaults to standard-group card when appearance is empty', ->
+      result = @parse('', 'repeat')
+      expect(result.card).toBe('standard-group')
+      expect(result.columnCount).toBe(null)
+
+    it 'recognises table-list', ->
+      result = @parse('table-list', 'repeat')
+      expect(result.card).toBe('table-list')
+
+    it 'field-list maps to same-screen (matching group behaviour)', ->
+      result = @parse('field-list', 'repeat')
+      expect(result.card).toBe('same-screen')
+
+    it 'w-token is stripped — defaults to standard-group (groups have no column-count card)', ->
+      result = @parse('w3', 'repeat')
+      expect(result.card).toBe('standard-group')
+
+    it 'matches group card set for an unknown value', ->
+      groupResult = @parse('unknown-value', 'group')
+      repeatResult = @parse('unknown-value', 'repeat')
+      expect(repeatResult.card).toBe(groupResult.card)
+
+  ###############################################################
+  # view.rowDetail: isCardGridType — repeat type
+  ###############################################################
+  describe 'view.rowDetail.DetailViewMixins.appearance: isCardGridType() for repeat', ->
+    beforeEach ->
+      @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      @mixin = @viewRowDetail.DetailViewMixins.appearance
+
+    it 'returns true for repeat type', ->
+      ctx = model_type: -> 'repeat'
+      expect(@mixin.isCardGridType.call(ctx)).toBe(true)
+
+  ###############################################################
+  # view.rowDetail: appearance panel renders Columns in Grid for repeat
+  ###############################################################
+  describe 'view.rowDetail.DetailViewMixins: "appearance" (repeat) — renders Columns in Grid', ->
+    beforeEach ->
+      window.xlfHideWarnings = true
+      sessionStorage.setItem('kpi.editable-form.form-style', 'theme-grid')
+      @viewRowDetail = require('../../jsapp/xlform/src/view.rowDetail')
+      $model = require('../../jsapp/xlform/src/_model')
+      @survey = new $model.Survey()
+      @survey.rows.add(type: 'repeat', name: 'rep1', label: 'Repeat 1')
+      @row = @survey.rows.at(0)
+      @detail = @row.get('appearance')
+      @mixin = @viewRowDetail.DetailViewMixins.appearance
+      @$el = $('<div/>')
+      @$cardSettingsWrap = $('<div><div class="js-card-settings-appearance"></div></div>')
+      @mixin_ctx = $.extend({}, @mixin, {
+        cid: 'cid_rep_appearance'
+        $el: @$el
+        $: (sel) => @$el.find(sel)
+        model: @detail
+        listenTo: ->
+        Templates: @viewRowDetail.Templates
+        rowView: { cardSettingsWrap: @$cardSettingsWrap, model: @row }
+      })
+      @mixin_ctx.html()
+    afterEach ->
+      window.xlfHideWarnings = false
+      sessionStorage.removeItem('kpi.editable-form.form-style')
+
+    it 'renders the Columns in Grid section (.js-group-cols-wrap)', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      expect(@$cardSettingsWrap.find('.js-group-cols-wrap').length).toBe(1)
+
+    it 'renders the same appearance card set as a group', ->
+      @mixin_ctx.afterRender.call(@mixin_ctx)
+      repeatCards = @$el.find('.appearance-card').map(-> $(@).data('card-slug')).get()
+      @survey2 = new (require('../../jsapp/xlform/src/_model')).Survey()
+      @survey2.rows.add(type: 'group', name: 'grp1', label: 'Group 1')
+      groupRow = @survey2.rows.at(0)
+      groupDetail = groupRow.get('appearance')
+      $el2 = $('<div/>')
+      $wrap2 = $('<div><div class="js-card-settings-appearance"></div></div>')
+      groupCtx = $.extend({}, @mixin, {
+        cid: 'cid_grp2'
+        $el: $el2
+        $: (sel) => $el2.find(sel)
+        model: groupDetail
+        listenTo: ->
+        Templates: @viewRowDetail.Templates
+        rowView: { cardSettingsWrap: $wrap2, model: groupRow }
+      })
+      groupCtx.html()
+      groupCtx.afterRender.call(groupCtx)
+      groupCards = $el2.find('.appearance-card').map(-> $(@).data('card-slug')).get()
+      expect(repeatCards).toEqual(groupCards)


### PR DESCRIPTION
Imported XLSForm repeat groups have internal type 'repeat' instead of 'group'. Since 'repeat' was missing from isCardGridType(), these groups skipped the card grid render path — leaving no appearance panel, no "Columns in Grid" section, and no form style change listener. Added 'repeat' alongside 'group' in 5 checks in view.rowDetail.coffee.