### PR TITLE
OC-28416: Show save-draft message in Manage Languages only when form …

### DIFF
--- a/jsapp/js/components/bigModal/bigModal.js
+++ b/jsapp/js/components/bigModal/bigModal.js
@@ -381,7 +381,7 @@ class BigModal extends React.Component {
             <RESTServicesForm assetUid={this.props.params.assetUid} hookUid={this.props.params.hookUid} />
           )}
           {this.props.params.type === MODAL_TYPES.FORM_LANGUAGES && (
-            <TranslationSettings asset={this.props.params.asset} />
+            <TranslationSettings asset={this.props.params.asset} hasUnsavedChanges={this.props.params.hasUnsavedChanges} />
           )}
           {this.props.params.type === MODAL_TYPES.FORM_TRANSLATIONS_TABLE && (
             <TranslationTable

--- a/jsapp/js/components/bigModal/bigModal.js
+++ b/jsapp/js/components/bigModal/bigModal.js
@@ -381,7 +381,10 @@ class BigModal extends React.Component {
             <RESTServicesForm assetUid={this.props.params.assetUid} hookUid={this.props.params.hookUid} />
           )}
           {this.props.params.type === MODAL_TYPES.FORM_LANGUAGES && (
-            <TranslationSettings asset={this.props.params.asset} hasUnsavedChanges={this.props.params.hasUnsavedChanges} />
+            <TranslationSettings
+              asset={this.props.params.asset}
+              hasUnsavedChanges={this.props.params.hasUnsavedChanges}
+            />
           )}
           {this.props.params.type === MODAL_TYPES.FORM_TRANSLATIONS_TABLE && (
             <TranslationTable

--- a/jsapp/js/components/modalForms/TranslationSettings.tsx
+++ b/jsapp/js/components/modalForms/TranslationSettings.tsx
@@ -20,6 +20,7 @@ import { type LangObject, escapeHtml, getLangString, notify } from '#/utils'
 
 interface TranslationSettingsProps {
   asset: AssetResponse
+  hasUnsavedChanges?: boolean
 }
 
 interface TranslationSettingsState {
@@ -300,6 +301,16 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
     )
   }
 
+  renderSaveDraftMessage() {
+    return (
+      <bem.FormModal m='translation-settings'>
+        <bem.FormModal__item>
+          <bem.FormView__cell>{t('You must save this draft before you can manage languages.')}</bem.FormView__cell>
+        </bem.FormModal__item>
+      </bem.FormModal>
+    )
+  }
+
   renderUndefinedDefaultSettings() {
     return (
       <bem.FormModal m='translation-settings'>
@@ -465,7 +476,7 @@ export class TranslationSettings extends React.Component<TranslationSettingsProp
 
     const translations = this.state.translations
     if (!translations || translations?.length === 0) {
-      return this.renderEmptyMessage()
+      return this.props.hasUnsavedChanges ? this.renderSaveDraftMessage() : this.renderEmptyMessage()
     } else if (translations?.length === 1 && translations[0] === null) {
       // use this modal if there are only unnamed translations
       return this.renderUndefinedDefaultSettings()

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -1053,6 +1053,7 @@ export default function EditableForm(props: EditableFormProps) {
       pageState.showModal({
         type: MODAL_TYPES.FORM_LANGUAGES,
         asset: state.asset,
+        hasUnsavedChanges: needsSave(),
       })
     }
   }


### PR DESCRIPTION
…has unsaved changes

### 📣 Summary

Updates the "Manage Languages" modal to show "You must save this draft before you can manage languages." only when there are unsaved form changes, and restores the original "There is nothing to translate in this form." message when the form is saved but has no questions.